### PR TITLE
Fix for #265 Docker build in nl-generic-functions-ig is broken

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:24-jdk-bookworm
+FROM eclipse-temurin:21-jdk-jammy
 LABEL maintainer="roland@headease.nl"
 
 # Install native compilation dependencies.


### PR DESCRIPTION
- Changed the base image:
```
FROM eclipse-temurin:21-jdk-jammy
```