### PR TITLE
Add user authentication

### DIFF
--- a/input/images-source/oidc4vci-consentvc-issuance.plantuml
+++ b/input/images-source/oidc4vci-consentvc-issuance.plantuml
@@ -1,0 +1,95 @@
+@startuml openid4vci-consent-issuance
+
+title OpenID4VCI: Request UserConsentCredential
+
+skinparam roundcorner 20
+skinparam defaultFontName Arial 
+hide footbox
+autoactivate on
+
+participant user as "User\n browser"
+participant ehr as "Client\n ehr.app"
+participant idp as "IDP\n idp.example"
+participant rs as "Resource Server\n rs.app"
+
+user -> ehr: GET /external-resource
+
+ehr -> idp: GET /.well-known/openid-credential-issuer
+idp --> ehr: 200 OK
+
+note left
+{
+  "credential_issuer": "https://idp.example",
+  "authorization_servers": [
+    "https://auth.idp.example"
+  ],
+  "credential_endpoint": "https://idp.example/credential",
+  "credential_configuration_ids": {
+    "UserConsentCredential": {
+      "format": "jwt_vc_json",
+      "cryptographic_binding_methods_supported": [
+        "did:web", "did:key"
+      ],
+      ...
+    }
+  }
+}
+end note
+
+
+group OpenID4VCI: Authorization Code Flow
+
+autonumber
+ehr --> user: 302 Found: auth.idp.example/authorize
+user -> idp: GET /authorize
+note right
+response_type=code
+  &client_id=ehr.app
+  &authorization_details...
+  &redirect_uri=https://ehr.app/callback
+end note
+idp --> user: 200 OK
+note left: html with\n consent form
+user -> idp: POST /consent
+note right: "User Alice consents to Organization A\n acting on her behalf"
+idp --> user: 302 Found: ehr.app/callback
+note left: code=Spl...
+user -> ehr: GET /callback
+ehr -> idp: POST /token
+note right
+grant_type=authorization_code
+  &client_id=ehr.app
+  &code=Spl...
+  &redirect_uri=https://ehr.app/callback
+end note
+idp --> ehr: 200 OK
+note left: access-token
+ehr -> idp: POST /credential
+note right
+Authorization: access-token
+
+{
+  "format": "jwt_vc_json",
+  "credential_definition": {
+    "type": ["VerifiableCredential",
+      "UserConsentCredential"]
+  },
+  "proof": {
+    "proof_type": "jwt",
+    "jwt": "eyJ..."
+  }
+}
+end note
+idp --> ehr: 200 OK
+note left: credential
+autonumber stop
+end
+ehr -> rs: [GFI-004]: Request AT
+rs --> ehr: 200 OK
+ehr -> rs: GET /resource
+rs --> ehr: 200 OK
+note left: external-resource
+ehr --> user: 200 OK
+note left: html with\n external resource
+
+@enduml

--- a/input/images-source/user-authentication.plantuml
+++ b/input/images-source/user-authentication.plantuml
@@ -1,0 +1,61 @@
+@startuml user-authentication
+
+skinparam roundcorner 20
+skinparam defaultFontName Arial 
+hide footbox
+autoactivate on
+autonumber
+
+!pragma teoz true
+
+participant  user as "User"
+participant  ehr as "Client\n (EHR)"
+participant idp as "Identity Provider\n (IDP)"
+participant as as "Resource Server\n (AS)"
+
+== Session Establishment (OIDC) ==
+
+user -> ehr: Login
+ehr --> user: Redirect to IDP
+user -> idp: Authenticate (e.g., DigiD)
+
+idp --> user: Redirect with code
+
+user -> ehr: follow redirect
+ehr -> idp: exchange code
+
+idp --> ehr: id-token
+deactivate
+
+== Credential Issuance (OpenID4VCI) ==
+
+user -> ehr: Access external resource
+ehr --> user: Redirect to idp
+user -> idp: follow redirect
+
+alt First time, no consent given
+    user -> idp: Give consent
+    deactivate idp
+end
+
+idp --> user: Redirect with code
+user -> ehr: Follow redirect
+ehr -> idp: Exchange code
+idp --> ehr: Access token
+ehr -> idp: Request credential
+idp --> ehr: User Consent VC
+
+== Request Access Token ==
+
+ehr -> as: Request access token\n VP: Org VC + User Consent VC
+as --> ehr: access token
+
+== Request Resource ==
+
+ehr -> as: request resource
+as --> ehr: resource
+ehr --> user: show information
+
+
+@enduml
+

--- a/input/pagecontent/user-authentication.md
+++ b/input/pagecontent/user-authentication.md
@@ -182,40 +182,11 @@ The Authorization Code Flow is used for credential issuance because it:
 
 #### Message Flow
 
-```
-┌────────┐      ┌─────────┐      ┌────────┐
-│ Client │      │ Browser │      │  IDP   │
-└───┬────┘      └────┬────┘      └───┬────┘
-    │                │               │
-    │ 1. Redirect to /authorize      │
-    │───────────────>│               │
-    │                │ 2. GET /authorize
-    │                │   (with session cookie)
-    │                │──────────────>│
-    │                │               │
-    │                │   Session valid? ───┐
-    │                │                     │ Yes: skip login
-    │                │   Consent needed? ──┤
-    │                │                     │ No: skip consent
-    │                │               │<────┘
-    │                │               │
-    │                │ 3. Redirect back with code
-    │                │<──────────────│
-    │ 4. Code        │               │
-    │<───────────────│               │
-    │                │               │
-    │ 5. POST /token (exchange code) │
-    │───────────────────────────────>│
-    │ 6. Access token                │
-    │<───────────────────────────────│
-    │                │               │
-    │ 7. POST /credential            │
-    │───────────────────────────────>│
-    │ 8. User Consent VC             │
-    │<───────────────────────────────│
-```
+<div>
+{% include openid4vci-consent-issuance.svg %}
+</div>
 
-With an active session and pre-approved consent, steps 2-3 complete in milliseconds.
+With an active session and pre-approved consent, steps 2-5 complete in milliseconds.
 
 #### Authorization Request
 

--- a/input/pagecontent/user-authentication.md
+++ b/input/pagecontent/user-authentication.md
@@ -1,0 +1,43 @@
+# User authentication
+
+How to authenticate an end user to another party?
+
+Let the user authenticate itself at a trusted identity provider(IDP).
+
+This identity will be presented alongside other attributes to the authorization server of the resource server.
+
+## Requirements
+
+- User should not authenticate/login for every access token request.
+- User can work for multiple healthcare organization
+- User can have a role specific for a given healthcare organization
+- The solution can both be used to authenticate employees (care givers) in their own EHR as it can be used to authenticate to third parties.
+
+## Solution direction
+
+User creates an active session with the IDP by loggin in with a trusted means like DigID or a european wallet. The IDP now knows the user. The login session is initiated from the EHR of the healthcare provider the user is currently working. After authenticating the EHR receives the identity of the user via a id-token or by interacting with the /userinfo endpoin
+
+Then, when the user initiates an interaction with an external care provider, the EHR initates a signing session with the IDP. Ideally the user still has an open session and does not have to login again. The session can also be recreated by providing a refresh token to the IDP.
+
+The user has to answer a quiestion in the form of: "Do you want your identity be shared with CareProvider X?". If the user agrees, the IDP creates a token which contains the identity of the user and the audience of CareProvder X.
+
+The requesting organization sends this token to the AS of CareProvder X which can validate the claim and then issue an access token which cab be used by the client to fetch resources.
+
+## Actors
+
+Relying party
+IDP
+Signing service
+Authentication server
+Resource server
+
+create session:
+
+RP -> user: redirct to IDP
+user -> IDP: login
+idp -> user: redirect back to RP with code
+user -> RP: offer code
+RP -> IDP: fetch id-token
+
+sign a statement:
+RP -> IDP: start signing session

--- a/input/pagecontent/user-authentication.md
+++ b/input/pagecontent/user-authentication.md
@@ -1,43 +1,734 @@
-# User authentication
+### Introduction
 
-How to authenticate an end user to another party?
+User authentication establishes the identity of an end-user (typically a healthcare professional) in cross-organizational data exchanges. While the [Authentication](authentication.html) section describes how organizations and service providers authenticate using Verifiable Credentials, this section extends that model to include authenticated end-users.
 
-Let the user authenticate itself at a trusted identity provider(IDP).
+The result of user authentication is a **User Consent Credential** - a short-lived Verifiable Credential issued by a trusted Identity Provider (IDP) that attests to a user's consent for their organization to act on their behalf. This credential can be included in the Verifiable Presentation sent to an Authorization Server as part of the [Request Access Token \[GFI-004\]](GFI-004.html) transaction.
 
-This identity will be presented alongside other attributes to the authorization server of the resource server.
+### Problem Overview
 
-## Requirements
+Healthcare professionals need to access patient data across organizational boundaries. The receiving organization's Authorization Server must verify:
 
-- User should not authenticate/login for every access token request.
-- User can work for multiple healthcare organization
-- User can have a role specific for a given healthcare organization
-- The solution can both be used to authenticate employees (care givers) in their own EHR as it can be used to authenticate to third parties.
+1. **Organization identity** - Which care organization is requesting access?
+2. **User identity** - Which healthcare professional is initiating the request?
 
-## Solution direction
+The generic authentication model (see [Authentication](authentication.html)) addresses organization and service provider identity through long-lived Verifiable Credentials issued by authoritative registries. However, user identity presents additional challenges:
 
-User creates an active session with the IDP by loggin in with a trusted means like DigID or a european wallet. The IDP now knows the user. The login session is initiated from the EHR of the healthcare provider the user is currently working. After authenticating the EHR receives the identity of the user via a id-token or by interacting with the /userinfo endpoin
+- Users should not authenticate for every access token request (user experience)
+- Users may work for multiple healthcare organizations
+- Users may have different roles at different organizations
+- User authentication must prove "liveness" - that the user is actively present
+- The solution must work for both internal EHR access and cross-organizational exchanges
 
-Then, when the user initiates an interaction with an external care provider, the EHR initates a signing session with the IDP. Ideally the user still has an open session and does not have to login again. The session can also be recreated by providing a refresh token to the IDP.
+### Requirements
 
-The user has to answer a quiestion in the form of: "Do you want your identity be shared with CareProvider X?". If the user agrees, the IDP creates a token which contains the identity of the user and the audience of CareProvder X.
+The user authentication solution must:
 
-The requesting organization sends this token to the AS of CareProvder X which can validate the claim and then issue an access token which cab be used by the client to fetch resources.
+- **Integrate with the existing VC/VP model** - User identity is expressed as a Verifiable Credential that can be combined with other credentials in a Verifiable Presentation.
+- **Support session-based authentication** - Users authenticate once and can perform multiple operations without re-authenticating for each request.
+- **Provide user liveness guarantees** - The credential must prove the user was recently authenticated.
+- **Support audience restriction** - Presentations should be bound to specific recipients to prevent replay attacks.
+- **Enable user consent** - Users must consent to sharing their identity with specific parties.
+- **Leverage existing identity solutions** - Build on established authentication methods (e.g., DigiD, eHerkenning, European Digital Identity Wallet).
+- **Be compatible with various (trusted) IDP implementations** - Support possible different trusted Identity Providers.
 
-## Actors
+### Terminology
 
-Relying party
-IDP
-Signing service
-Authentication server
-Resource server
+In addition to the terminology defined in [Authentication](authentication.html), this section uses:
 
-create session:
+- **User**: An end-user, typically a healthcare professional, who initiates data access requests.
+- **Identity Provider (IDP)**: A trusted party that authenticates users and issues User Consent Credentials. The IDP acts as an Issuer in the VC model.
+- **User Consent Credential**: A short-lived Verifiable Credential representing a user's consent for their organization to act on their behalf.
+- **Authentication Session**: A time-limited session between the user and the IDP, established through user authentication.
+- **Relying Party (RP)**: The client application (e.g., EHR system) that relies on the IDP to authenticate users.
 
-RP -> user: redirct to IDP
-user -> IDP: login
-idp -> user: redirect back to RP with code
-user -> RP: offer code
-RP -> IDP: fetch id-token
+### Credential Semantics
 
-sign a statement:
-RP -> IDP: start signing session
+This section explains the semantic model of the User Consent Credential and how it differs from a simple identity assertion.
+
+#### What does the credential represent?
+
+The User Consent Credential represents a **delegation of authority**: the user (Alice) authorizes their organization (Organization A) to act on their behalf when accessing external resources.
+
+**Statement**: "Alice (authenticated by this IDP) consents to Organization A acting on her behalf"
+
+This is fundamentally different from:
+- A pure identity credential ("This is Alice") - which would have the user as subject
+- An employment credential ("Alice works for Org A") - which would be issued by the organization
+
+#### Credential Structure
+
+```
+Issuer:  IDP (trusted third party that authenticated the user)
+Subject: Organization A (the entity receiving the delegation)
+Holder:  Organization A (presents the credential)
+Claims:  User identity, consent timestamp
+```
+
+The **subject is the organization**, not the user, because:
+1. The credential answers: "Is Organization A authorized to act on behalf of a user?"
+2. Organization A is the holder presenting the credential
+3. The verifier is checking Organization A's authorization to act
+
+#### Consent Scope
+
+The User Consent Credential represents **broad consent** - the user trusts their employer to act appropriately on their behalf. This aligns with the employment relationship where:
+- The user works for the organization
+- The organization is accountable for appropriate use
+- Audit trails track which credentials were used
+
+This is distinct from **specific consent** where each recipient would need to be named in the credential. Specific consent per verifier would require:
+- A new credential for each external party
+- More user interactions
+- Custom claims outside the VC Data Model
+
+#### Audience Binding
+
+The [Verifiable Credentials Data Model 1.1](https://www.w3.org/TR/vc-data-model/) does not include an `aud` (audience) property in the credential itself. Audience binding is a property of the **Verifiable Presentation**, not the credential.
+
+This means:
+- The User Consent Credential has **no audience restriction** in the VC itself
+- When presenting to a specific verifier, the **VP includes the audience** (`aud` claim)
+- The short credential lifetime provides temporal binding (liveness)
+- The VP signature binds all contained credentials to that specific transaction
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Verifiable Presentation (JWT)                           │
+│                                                         │
+│ iss: did:web:org-a.example.com (holder/presenter)      │
+│ aud: did:web:org-b.example.com (verifier) ← BINDING    │
+│ iat: 1704067200                                         │
+│ exp: 1704067260 (very short-lived)                     │
+│                                                         │
+│ vp: {                                                   │
+│   verifiableCredential: [                              │
+│     <organization-credential>,                          │
+│     <user-consent-credential>  ← no aud in VC          │
+│   ]                                                     │
+│ }                                                       │
+└─────────────────────────────────────────────────────────┘
+```
+
+This approach:
+- Follows the VC Data Model standard
+- Keeps credentials portable (not locked to one verifier)
+- Places trust in the organization to use credentials appropriately
+- Relies on short credential lifetime for liveness guarantees
+
+### Solution Overview
+
+The user authentication flow consists of two phases:
+
+1. **Session Establishment** - The user authenticates with an Identity Provider, creating an authentication session.
+2. **Credential Issuance** - When accessing external resources, the IDP issues a short-lived User Consent Credential.
+
+The User Consent Credential is then included in the Verifiable Presentation alongside other credentials (organization, service provider) when requesting access tokens via [GFI-004](GFI-004.html).
+
+#### Architecture
+
+The following diagram shows the complete flow from initial login through credential issuance to accessing external resources.
+
+```
+┌──────────┐      ┌──────────┐      ┌──────────────────┐      ┌─────────────────┐
+│   User   │      │  Client  │      │ Identity Provider│      │ Resource Server │
+│          │      │  (EHR)   │      │      (IDP)       │      │      (AS)       │
+└────┬─────┘      └────┬─────┘      └────────┬─────────┘      └────────┬────────┘
+     │                 │                     │                         │
+     │                 │   === Session Establishment (OIDC) ===        │
+     │ 1. Login        │                     │                         │
+     │────────────────>│                     │                         │
+     │                 │ 2. Redirect /authorize                        │
+     │<─ ─ ─ ─ ─ ─ ─ ─ ┤────────────────────>│                         │
+     │                 │                     │                         │
+     │ 3. Authenticate (e.g., DigiD)         │                         │
+     │──────────────────────────────────────>│                         │
+     │                 │                     │                         │
+     │ 4. Redirect back with code            │                         │
+     │<──────────────────────────────────────│                         │
+     │─ ─ ─ ─ ─ ─ ─ ─ >│                     │                         │
+     │                 │ 5. Exchange code    │                         │
+     │                 │────────────────────>│                         │
+     │                 │ 6. ID Token         │                         │
+     │                 │<────────────────────│                         │
+     │                 │                     │                         │
+     │ ... time passes, user works in EHR ...│                         │
+     │                 │                     │                         │
+     │                 │   === Credential Issuance (OpenID4VCI) ===    │
+     │ 7. Access external resource           │                         │
+     │────────────────>│                     │                         │
+     │                 │ 8. Redirect /authorize                        │
+     │<─ ─ ─ ─ ─ ─ ─ ─ ┤    (credential request)                       │
+     │                 │────────────────────>│                         │
+     │                 │                     │                         │
+     │ 9. (Session valid → instant, or consent screen)                 │
+     │<──────────────────────────────────────│                         │
+     │                 │                     │                         │
+     │ 10. Redirect back with code           │                         │
+     │<──────────────────────────────────────│                         │
+     │─ ─ ─ ─ ─ ─ ─ ─ >│                     │                         │
+     │                 │ 11. Exchange code   │                         │
+     │                 │────────────────────>│                         │
+     │                 │ 12. Access token    │                         │
+     │                 │<────────────────────│                         │
+     │                 │ 13. POST /credential│                         │
+     │                 │────────────────────>│                         │
+     │                 │ 14. User Consent VC │                         │
+     │                 │<────────────────────│                         │
+     │                 │                     │                         │
+     │                 │   === Resource Access (GFI-004) ===           │
+     │                 │ 15. Request Access Token                      │
+     │                 │     VP: Org VC + User Consent VC             │
+     │                 │──────────────────────────────────────────────>│
+     │                 │                     │                         │
+     │                 │ 16. Access Token    │                         │
+     │                 │<─────────────────────────────────────────────│
+     │                 │                     │                         │
+```
+
+**Note**: Steps 8-10 (the authorization redirect for credential issuance) are near-instant if the user has a valid browser session with the IDP and has previously consented. The user may only see a brief loading indicator.
+
+#### Actors and Transactions
+
+**Table: User Authentication - Actors and Transactions**
+
+| Actor             | Transaction                      | Initiator or Responder | Optionality | Reference                                           |
+| ----------------- | -------------------------------- | ---------------------- | ----------- | --------------------------------------------------- |
+| User              | Authenticate with IDP            | Initiator              | R           | [Session Establishment](#session-establishment)     |
+|                   | Consent to credential issuance   | Responder              | R           | [Credential Issuance](#credential-issuance)         |
+| Identity Provider | Authenticate User                | Responder              | R           | [Session Establishment](#session-establishment)     |
+|                   | Issue User Consent Credential   | Initiator              | R           | [Credential Issuance](#credential-issuance)         |
+|                   | Resolve key material [GFI-001]   | Responder              | R           | [\[GFI-001\]](GFI-001.html)                         |
+| Client (RP/EHR)   | Initiate user authentication     | Initiator              | R           | [Session Establishment](#session-establishment)     |
+|                   | Request User Consent Credential | Initiator              | R           | [Credential Issuance](#credential-issuance)         |
+|                   | Request Access Token [GFI-004]   | Initiator              | R           | [\[GFI-004\]](GFI-004.html)                         |
+| Verifier (AS)     | Verify User Consent Credential  | Responder              | R           | [Credential Verification](#credential-verification) |
+|                   | Resolve key material [GFI-001]   | Initiator              | R           | [\[GFI-001\]](GFI-001.html)                         |
+
+{: .grid .table-striped}
+
+### Session Establishment
+
+The user establishes an authentication session with the Identity Provider using standard OpenID Connect flows.
+
+#### Trigger Events
+
+- User opens the client application (EHR) and needs to login/authenticate.
+- User's existing session has expired during a credential issuance.
+
+#### Message Flow
+
+1. The client redirects the user to the IDP's authorization endpoint.
+2. The user authenticates using a trusted authentication method (e.g., DigiD, UZI-smart card, Wallet).
+3. Upon successful authentication, the IDP redirects back to the client with an authorization code.
+4. The client exchanges the authorization code for tokens (ID token, access token, optionally refresh token).
+
+#### Referenced Standards
+
+- [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html)
+- Authentication methods as required by the IDP's trust framework (e.g., DigiD, UZI-Smart card, EUDI Wallet)
+
+#### Session Characteristics
+
+- The authentication session is established between the user's browser and the IDP.
+- Session lifetime should balance security (shorter) with user experience (longer).
+- The client may receive a refresh token to maintain access without requiring re-authentication.
+- The session does NOT directly result in a Verifiable Credential - that happens in the next phase.
+
+### Credential Issuance
+
+When the client needs to access external resources on behalf of the user, it requests a User Consent Credential from the IDP using the [OpenID4VCI 1.0](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html) Authorization Code Flow. This credential is short-lived to provide user liveness guarantees.
+
+#### Trigger Events
+
+- The client needs to request an access token from an external Authorization Server.
+- The use-case or external Authorization Server requires proof of user identity.
+
+#### Why Authorization Code Flow
+
+The Authorization Code Flow is used for credential issuance because it:
+
+- **Guarantees user liveness** - The browser redirect proves the user is present at the time of credential issuance.
+- **Enables explicit consent** - The IDP can display what identity information will be shared and with whom.
+- **Is near-instant with active session** - If the user has a valid browser session with the IDP, the redirects happen in milliseconds. The user may only see a brief loading state.
+- **Uses standard protocols** - Built on OAuth 2.0 and OpenID4VCI, widely supported.
+- **Handles session expiry gracefully** - If the session has expired, the user is prompted to re-authenticate.
+
+#### Message Flow
+
+```
+┌────────┐      ┌─────────┐      ┌────────┐
+│ Client │      │ Browser │      │  IDP   │
+└───┬────┘      └────┬────┘      └───┬────┘
+    │                │               │
+    │ 1. Redirect to /authorize      │
+    │───────────────>│               │
+    │                │ 2. GET /authorize
+    │                │   (with session cookie)
+    │                │──────────────>│
+    │                │               │
+    │                │   Session valid? ───┐
+    │                │                     │ Yes: skip login
+    │                │   Consent needed? ──┤
+    │                │                     │ No: skip consent
+    │                │               │<────┘
+    │                │               │
+    │                │ 3. Redirect back with code
+    │                │<──────────────│
+    │ 4. Code        │               │
+    │<───────────────│               │
+    │                │               │
+    │ 5. POST /token (exchange code) │
+    │───────────────────────────────>│
+    │ 6. Access token                │
+    │<───────────────────────────────│
+    │                │               │
+    │ 7. POST /credential            │
+    │───────────────────────────────>│
+    │ 8. User Consent VC             │
+    │<───────────────────────────────│
+```
+
+With an active session and pre-approved consent, steps 2-3 complete in milliseconds.
+
+#### Authorization Request
+
+The client initiates credential issuance by redirecting the user to the IDP's authorization endpoint. The request uses [RFC 9396 Rich Authorization Requests](https://datatracker.ietf.org/doc/html/rfc9396) to specify the credential type:
+
+```
+GET /authorize?
+  response_type=code&
+  client_id=ehr.care-org.example.com&
+  redirect_uri=https://ehr.care-org.example.com/credential-callback&
+  authorization_details=%5B%7B%22type%22%3A%22openid_credential%22%2C%22credential_configuration_id%22%3A%22UserIdentityCredential%22%7D%5D&
+  code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&
+  code_challenge_method=S256&
+  state=xyz789
+Host: idp.example.com
+```
+
+The `authorization_details` parameter (URL-decoded) contains:
+
+```json
+[{
+  "type": "openid_credential",
+  "credential_configuration_id": "UserIdentityCredential"
+}]
+```
+
+##### Request Parameters
+
+| Parameter | Required | Description |
+| --------- | -------- | ----------- |
+| `response_type` | R | Must be `code` |
+| `client_id` | R | The client's identifier at the IDP |
+| `redirect_uri` | R | Where to send the authorization code |
+| `authorization_details` | R | JSON array specifying the credential type per RFC 9396 |
+| `code_challenge` | R | PKCE challenge (SHA256 of code_verifier, base64url-encoded) |
+| `code_challenge_method` | R | Must be `S256` |
+| `state` | R | Opaque value for CSRF protection |
+| `issuer_state` | O | Binds request to previous IDP context (e.g., from credential offer) |
+| `prompt` | O | Controls IDP behavior (see below) |
+
+{: .grid .table-striped}
+
+##### The `prompt` Parameter
+
+The `prompt` parameter controls how the IDP handles the request:
+
+| Value | Behavior | Use Case |
+| ----- | -------- | -------- |
+| (omitted) | IDP decides based on session state and consent history | Default - recommended for most cases |
+| `none` | Silent - fail immediately if user interaction needed | Check if credential can be issued without user interaction |
+| `consent` | Always show consent screen | When explicit user approval is required |
+| `login` | Force re-authentication | For sensitive operations requiring fresh authentication |
+
+{: .grid .table-striped}
+
+**Recommended pattern**: First try with `prompt=none`. If the IDP returns `interaction_required` or `consent_required` error, retry without the prompt parameter to allow user interaction.
+
+#### User Consent
+
+When the user is redirected to the IDP:
+
+1. **Session check** - IDP verifies the user has a valid browser session. If not, the user must authenticate.
+2. **Consent check** - IDP determines if user consent is needed for this credential type.
+3. **Consent display** (if needed) - IDP shows what identity information will be included in the credential.
+4. **Authorization code** - Upon approval, IDP redirects back with an authorization code.
+
+The consent screen should clearly indicate:
+- That the user is authorizing their organization to act on their behalf
+- What identity claims will be included in the credential
+- That the credential may be used to access external resources
+
+If the user has previously consented to this credential type, the IDP may skip the consent screen (unless `prompt=consent` is specified).
+
+#### Token Exchange
+
+The client exchanges the authorization code for an access token, including the PKCE verifier:
+
+```
+POST /token HTTP/1.1
+Host: idp.example.com
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=authorization_code&
+code=SplxlOBeZQQYbYS6WxSbIA&
+redirect_uri=https://ehr.care-org.example.com/credential-callback&
+client_id=ehr.care-org.example.com&
+code_verifier=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
+```
+
+#### Credential Request
+
+Using the access token, the client requests the User Consent Credential from the credential endpoint:
+
+```
+POST /credential HTTP/1.1
+Host: idp.example.com
+Authorization: Bearer {access_token}
+Content-Type: application/json
+
+{
+  "format": "jwt_vc_json",
+  "credential_definition": {
+    "type": ["VerifiableCredential", "UserConsentCredential"]
+  }
+}
+```
+
+#### Credential Response
+
+The IDP returns a User Consent Credential as a JWT-encoded Verifiable Credential:
+
+```json
+{
+  "iss": "did:web:idp.example.com",
+  "sub": "did:web:care-org-a.example.com",
+  "iat": 1704067200,
+  "exp": 1704070800,
+  "nbf": 1704067200,
+  "jti": "urn:uuid:3978344f-8596-4c3a-a978-8fcaba3903c5",
+  "vc": {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "https://nuts.nl/credentials/v1"
+    ],
+    "type": ["VerifiableCredential", "UserConsentCredential"],
+    "credentialSubject": {
+      "id": "did:web:care-org-a.example.com",
+      "actingFor": {
+        "id": "did:web:idp.example.com:users:alice",
+        "givenName": "Alice",
+        "familyName": "Smith",
+        "identifier": {
+          "system": "urn:oid:2.16.528.1.1007.3.1",
+          "value": "123456789"
+        }
+      },
+      "consentGiven": "2024-01-01T10:30:00Z"
+    }
+  }
+}
+```
+
+The credential states: "The IDP attests that user Alice has consented to Organization A acting on her behalf."
+
+#### Credential Characteristics
+
+| Property | Value                      | Rationale                                       |
+| -------- | -------------------------- | ----------------------------------------------- |
+| Lifetime | Short (e.g., 5-60 minutes) | Provides user liveness guarantee                |
+| Subject  | Organization's DID         | The entity receiving the delegation             |
+| Issuer   | IDP's DID                  | Trusted third party that authenticated the user |
+
+{: .grid .table-striped}
+
+### Including User Consent in Access Token Requests
+
+The User Consent Credential is included in the Verifiable Presentation sent to the Authorization Server as part of [GFI-004](GFI-004.html).
+
+#### Verifiable Presentation Structure
+
+The VP contains multiple credentials:
+
+1. **Organization Credential** - Identifies the requesting care organization
+2. **User Consent Credential** - Attests user consent for the organization to act on their behalf
+3. **Service Provider Credential** (optional) - Identifies the software/service provider
+
+The VP's `aud` claim specifies the intended verifier, providing audience binding for the entire presentation:
+
+```json
+{
+  "iss": "did:web:care-org-a.example.com",
+  "aud": "did:web:care-org-b.example.com",
+  "iat": 1704067200,
+  "exp": 1704067260,
+  "jti": "urn:uuid:6c46d6e2-5b3a-4e7d-9f8a-1b2c3d4e5f6a",
+  "vp": {
+    "@context": ["https://www.w3.org/2018/credentials/v1"],
+    "type": ["VerifiablePresentation"],
+    "verifiableCredential": [
+      "<organization-credential-jwt>",
+      "<user-consent-credential-jwt>"
+    ]
+  }
+}
+```
+
+Note that the VP is signed by `care-org-a` (the holder) and the `aud` is set to `care-org-b` (the verifier). The verifier checks that the User Consent Credential's subject matches the VP issuer.
+
+### Credential Verification
+
+The Authorization Server verifies the User Consent Credential as part of processing the access token request.
+
+#### Verification Steps
+
+1. **Verify VP audience** - Confirm the VP's `aud` claim matches the Authorization Server's identifier.
+2. **Verify VP signature** - Verify the VP is signed by the presenting organization. The VP's `iss` claim identifies the presenter.
+3. **Extract credentials** - Identify the User Consent Credential among the presented credentials.
+4. **Verify credential signature** - Resolve the IDP's DID ([GFI-001](GFI-001.html)) and verify the credential signature.
+5. **Verify holder binding** - Confirm the credential's subject (`credentialSubject.id`) matches the VP's issuer (`iss`). This ensures the organization presenting the VP is the same organization that received the user's consent.
+6. **Verify temporal validity** - Check `iat`, `nbf`, and `exp` claims on the credential.
+7. **Verify issuer trust** - Confirm the IDP is trusted for issuing User Consent Credentials.
+8. **Extract user claims** - Use the `actingFor` claims for authorization decisions and audit logging.
+
+#### Holder Binding Verification
+
+The holder binding check (step 5) is critical. It ensures that only the organization named in the credential can present it:
+
+```
+VP:
+  iss: did:web:care-org-a.example.com  ← presenter
+  aud: did:web:care-org-b.example.com  ← verifier
+
+User Consent Credential (inside VP):
+  credentialSubject.id: did:web:care-org-a.example.com  ← must match VP.iss
+```
+
+If `VP.iss` ≠ `credentialSubject.id`, the credential is being presented by an organization other than the one that received the consent, and MUST be rejected.
+
+#### Trust Framework Considerations
+
+The Authorization Server must maintain a list of trusted Identity Providers. This trust can be established through:
+
+- A published trust list of approved IDPs
+- Mutual agreements between organizations
+- A federated trust framework (e.g., based on eIDAS)
+
+### User Consent Credential Schema
+
+The User Consent Credential contains claims about the delegation of authority from user to organization.
+
+#### Credential Subject Claims
+
+| Claim | Required | Description |
+| ----- | -------- | ----------- |
+| `id` | R | The organization's DID (the entity receiving the delegation) |
+| `actingFor` | R | Object containing the user's identity claims |
+| `consentGiven` | O | Timestamp when consent was given |
+
+{: .grid .table-striped}
+
+#### User Claims (within `actingFor`)
+
+| Claim | Required | Description |
+| ----- | -------- | ----------- |
+| `id` | R | The user's DID at the IDP |
+| `givenName` | O | User's given name |
+| `familyName` | O | User's family name |
+| `identifier` | O | National identifier (e.g., BSN pseudonym, UZI number) |
+| `assuranceLevel` | O | Level of identity assurance (e.g., eIDAS level) |
+
+{: .grid .table-striped}
+
+The specific claims required depend on the use case and should be defined by the applicable trust framework.
+
+### Security Considerations
+
+#### Credential Lifetime
+
+User Consent Credentials should be short-lived (recommended: 5-60 minutes) to:
+
+- Ensure user liveness - the credential proves recent authentication
+- Limit exposure if credentials are compromised
+- Align with session timeout policies
+
+#### Audience Binding
+
+Audience binding occurs at the **Verifiable Presentation level**, not the credential level (see [Credential Semantics](#credential-semantics)). The VP's `aud` claim specifies the intended recipient:
+
+- The Authorization Server MUST verify the VP's `aud` claim matches its own identifier
+- The short credential lifetime limits the window for potential misuse
+- The organization (holder) is accountable for appropriate use of credentials
+
+#### Key Management
+
+- The IDP's signing keys must be properly secured (e.g., HSM)
+- Key rotation should be supported through DID document updates
+- Verifiers should cache DID documents appropriately (respecting cache headers)
+
+#### Session Security
+
+- Authentication sessions should be protected against session hijacking
+- Refresh tokens should be sender-constrained where possible
+- Session revocation should invalidate the ability to issue new credentials
+
+### Privacy Considerations
+
+#### Minimal Disclosure
+
+- Only include necessary claims in the User Consent Credential
+- Consider using pseudonymous identifiers where full identity is not required
+- Support selective disclosure where the trust framework allows
+
+#### User Consent
+
+- Users must be informed about what identity information is shared
+- Users should have the ability to deny credential issuance
+- Consent should be specific to the intended recipient
+
+#### Audit Trail
+
+- Both the IDP and the client should log credential issuance events
+- Logs should support accountability without unnecessarily exposing user data
+
+### Relationship to Other Specifications
+
+| Specification                         | Relationship                                                                  |
+| ------------------------------------- | ----------------------------------------------------------------------------- |
+| [Authentication](authentication.html) | User authentication extends the base authentication model with user consent   |
+| [GFI-001](GFI-001.html)               | IDP's DID is resolved to verify credential signatures                         |
+| [GFI-002](GFI-002.html)               | User Consent Credential issuance uses OpenID4VCI                              |
+| [GFI-004](GFI-004.html)               | User Consent Credential is included in the VP for access token requests       |
+| [Identification](identification.html) | User identifiers follow the identification guidelines                         |
+
+{: .grid .table-striped}
+
+### Example Flow
+
+This example shows the complete flow for a healthcare professional accessing patient data at an external care provider.
+
+#### 1. Session Establishment - User Authenticates with IDP
+
+The user logs into the EHR system. The client redirects to the IDP for authentication:
+
+```http
+GET /authorize?response_type=code&client_id=ehr.care-org.example.com&redirect_uri=https://ehr.care-org.example.com/callback&scope=openid%20profile&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256&state=abc123 HTTP/1.1
+Host: idp.example.com
+```
+
+User authenticates via DigiD. IDP redirects back:
+
+```http
+HTTP/1.1 302 Found
+Location: https://ehr.care-org.example.com/callback?code=SplxlOBeZQQYbYS6WxSbIA&state=abc123
+```
+
+#### 2. Client Exchanges Code for Session Tokens
+
+```http
+POST /token HTTP/1.1
+Host: idp.example.com
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=authorization_code&code=SplxlOBeZQQYbYS6WxSbIA&redirect_uri=https%3A%2F%2Fehr.care-org.example.com%2Fcallback&client_id=ehr.care-org.example.com&code_verifier=dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
+```
+
+Response:
+
+```json
+{
+  "access_token": "session_token_xyz",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "id_token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9..."
+}
+```
+
+User now works in the EHR system...
+
+#### 3. Credential Issuance - User Accesses External Resource
+
+When the user needs to access data at Care Provider X, the client initiates OpenID4VCI authorization code flow:
+
+```http
+GET /authorize?response_type=code&client_id=ehr.care-org.example.com&redirect_uri=https://ehr.care-org.example.com/credential-callback&authorization_details=%5B%7B%22type%22%3A%22openid_credential%22%2C%22credential_configuration_id%22%3A%22UserIdentityCredential%22%7D%5D&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM&code_challenge_method=S256&state=xyz789 HTTP/1.1
+Host: idp.example.com
+```
+
+Since the user has a valid session, the IDP immediately redirects back (or shows a brief consent screen for first-time access):
+
+```http
+HTTP/1.1 302 Found
+Location: https://ehr.care-org.example.com/credential-callback?code=Qcb0Orv1zh&state=xyz789
+```
+
+#### 4. Client Exchanges Code for Credential Access Token
+
+```http
+POST /token HTTP/1.1
+Host: idp.example.com
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=authorization_code&code=Qcb0Orv1zh&redirect_uri=https%3A%2F%2Fehr.care-org.example.com%2Fcredential-callback&client_id=ehr.care-org.example.com&code_verifier=another_verifier_string
+```
+
+#### 5. Client Requests User Consent Credential
+
+```http
+POST /credential HTTP/1.1
+Host: idp.example.com
+Authorization: Bearer {credential_access_token}
+Content-Type: application/json
+
+{
+  "format": "jwt_vc_json",
+  "credential_definition": {
+    "type": ["VerifiableCredential", "UserConsentCredential"]
+  }
+}
+```
+
+#### 6. IDP Returns User Consent Credential
+
+```json
+{
+  "credential": "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImlkcC1rZXktMSJ9...",
+  "format": "jwt_vc_json"
+}
+```
+
+#### 7. Client Requests Access Token at Resource Server (GFI-004)
+
+The client creates a Verifiable Presentation containing the Organization Credential and the User Consent Credential:
+
+```http
+POST /oauth/token HTTP/1.1
+Host: auth.care-provider-x.example.com
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9...&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer&client_assertion=eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+The `assertion` JWT contains a VP (with `aud` set to Care Provider X) containing:
+- Organization Credential (identifies Care Organization)
+- User Consent Credential (attests user consent for Care Organization to act on their behalf)
+
+#### 8. Resource Server Returns Access Token
+
+```json
+{
+  "access_token": "resource_access_token_abc",
+  "token_type": "DPoP",
+  "expires_in": 300
+}
+```
+
+The client can now access protected resources at Care Provider X using this access token.
+
+### Open Issues
+
+1. **IDP Discovery** - How does the Authorization Server discover which IDPs are trusted?
+2. **Role Claims** - Should role/function claims be included in the User Consent Credential (in `actingFor`) or in a separate Employment Credential issued by the organization?
+3. **Cross-border** - How does this align with eIDAS 2.0 and the EU Digital Identity Wallet?
+4. **Specific Consent** - Should there be an option for audience-specific consent (naming the intended recipient in the credential) for use cases requiring stronger guarantees?

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -92,6 +92,9 @@ pages:
     extension:
         - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
           valueCode: draft
+    user-authentication.md:
+      title: User Authentication
+      generation: markdown
     GFI-001.md:
       title: Request key material [GFI-001]
       generation: markdown


### PR DESCRIPTION
This PR adds a proposal for user authentication using trusted IDP's which can issue consent credentials which can be used in the GFI-004 transaction with other VCs in a VP.

Build: https://build.fhir.org/ig/nuts-foundation/nl-generic-functions-ig/branches/user-authn/user-authentication.html