### PR TITLE
docs(authorization): add Authorization Information Model draft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ Thumbs.db
 ################
 *.bak
 *.bkp
+.diagram-baseline/
 
 translations/
 

--- a/input/images-source/authorization-model-bridge.plantuml
+++ b/input/images-source/authorization-model-bridge.plantuml
@@ -12,7 +12,7 @@ skinparam nodesep 14
 skinparam ranksep 34
 hide circle
 
-title Layer 1 to Layer 2 bridge (generic model; concrete values marked "e.g.")
+title Information layer (L1) to trust layer (L2) bridge (generic model; concrete values marked "e.g.")
 
 ' --------- Layer 1 (yellow / orange) ---------
 class "Transaction  <<query>>\n[e.g. Raadplegen medicatieafspraak]" as TX #FFF2CC {
@@ -66,10 +66,10 @@ MITZ ..> PAT : about
 
 legend left
   Colour = layer:
-  Yellow = Layer 1 (Nictiz) concept
-  Orange = Layer 1 building-block dataset (imported)
-  Blue   = Layer 2 (trust framework): requester-provided claim / data-subject
-  Purple = Layer 2: evaluated source-side (not requester-provided)
+  Yellow = information layer (L1) concept
+  Orange = information layer: building-block dataset (imported)
+  Blue   = trust layer (L2): requester-provided claim / data-subject
+  Purple = trust layer: evaluated source-side (not requester-provided)
   --
   Arrows: solid = layer-1 structure; dashed = cross-layer reference
 endlegend

--- a/input/images-source/authorization-model-bridge.plantuml
+++ b/input/images-source/authorization-model-bridge.plantuml
@@ -1,0 +1,77 @@
+' SPDX-FileCopyrightText: 2026 Steven van der Vegt
+'
+' SPDX-License-Identifier: CC-BY-SA-4.0
+
+@startuml authorization-model-bridge
+
+skinparam defaultFontName Arial
+skinparam backgroundColor white
+skinparam roundcorner 5
+skinparam classFontStyle bold
+skinparam nodesep 14
+skinparam ranksep 34
+hide circle
+
+title Layer 1 to Layer 2 bridge (generic model; concrete values marked "e.g.")
+
+' --------- Layer 1 (yellow / orange) ---------
+class "Transaction  <<query>>\n[e.g. Raadplegen medicatieafspraak]" as TX #FFF2CC {
+  type = initial
+}
+class "QueryParameters  <<concept group>>" as QP #FFF2CC
+
+class "Patient identifier  <<identifier>>\n[e.g. Identificatienummer = BSN]" as PID #FFF2CC {
+  WHO the data is about (data-subject)
+}
+class "Query-scope identifiers  <<identifier>>\n[e.g. behandeling-id, record-id]" as SID #FFF2CC {
+  WHICH records to return, stays in layer 1
+}
+class "Query filters  <<filter>>\n[e.g. product code; usage period]" as QF #FFF2CC {
+  independent, each optional
+}
+
+class "Dataset (primary)  <<primary>>" as DSP #FFF2CC
+class "Dataset (building block)  <<zib>>" as DSB #FFE6CC
+
+' --------- Layer 2 (blue / purple) ---------
+class "Patient  <<data-subject>>" as PAT #DAE8FC
+
+class "HealthcareProfessional\n<<IdentityClaim, requester-provided>>" as HP #DAE8FC
+class "HealthcareOrganization\n<<IdentityClaim, requester-provided>>" as HO #DAE8FC
+class "Enrollment - treatment relationship\n<<ContextClaim, requester-provided>>" as ENR #DAE8FC
+class "Consent (e.g. Mitz or local registration)\n<<context check, source-side>>" as MITZ #E5D9F2
+
+' --------- Layer 1 structure ---------
+TX --> QP : profiles
+QP o-- PID
+QP o-- SID
+QP o-- QF
+QP --> "1" DSP : concepts member of
+DSP ..> DSB : imports (for payload concepts, not query params)
+PID -[hidden]down- SID
+SID -[hidden]down- QF
+
+' --------- claim layout: identity claims on one level, then context below ---------
+HP -[hidden]right- HO
+HP -[hidden]down- ENR
+ENR -[hidden]down- MITZ
+
+' --------- bridges ---------
+PID -[hidden]down- PAT
+PID ..> PAT : identifies (data-subject)
+TX ..> HP : requester is
+TX ..> HO : requester acts for
+ENR ..> PAT : about
+MITZ ..> PAT : about
+
+legend left
+  Colour = layer:
+  Yellow = Layer 1 (Nictiz) concept
+  Orange = Layer 1 building-block dataset (imported)
+  Blue   = Layer 2 (trust framework): requester-provided claim / data-subject
+  Purple = Layer 2: evaluated source-side (not requester-provided)
+  --
+  Arrows: solid = layer-1 structure; dashed = cross-layer reference
+endlegend
+
+@enduml

--- a/input/images-source/authorization-model-datasetconcept.plantuml
+++ b/input/images-source/authorization-model-datasetconcept.plantuml
@@ -1,0 +1,74 @@
+' SPDX-FileCopyrightText: 2026 Steven van der Vegt
+'
+' SPDX-License-Identifier: CC-BY-SA-4.0
+
+@startuml authorization-model-datasetconcept
+
+skinparam defaultFontName Arial
+skinparam backgroundColor white
+skinparam roundcorner 5
+skinparam classFontStyle bold
+hide circle
+
+title What a transaction carries: DatasetConcept, inheritance and per-transaction restriction
+
+class Transaction #FFF2CC {
+  name
+  version
+  type : initial | back | stationary
+}
+
+class TransactionConcept #EEEEEE {
+  conformance?  [restricts baseline]
+  cardinality?  [restricts baseline]
+  condition?
+}
+note bottom of TransactionConcept
+  One entry of the transaction dataset.
+  Optional restriction; blank = inherit
+  the concept's baseline. A transaction
+  may only narrow, never loosen.
+end note
+
+class DatasetConcept #FFF2CC {
+  id : OID
+  effectiveDate
+  type : group | item
+  name
+  valueDomain    [item only]
+  conformance    [baseline]
+  cardinality    [baseline]
+}
+
+class Dataset #FFF2CC {
+  name
+  version
+  role : primary | building-block (zib)
+}
+
+class ValueSet #DAE8FC {
+  name
+  version
+}
+
+Transaction "*" - "*" DatasetConcept
+(Transaction, DatasetConcept) .. TransactionConcept
+
+DatasetConcept "group 1" o-- "* children" DatasetConcept : contains (concept tree)
+DatasetConcept "* derived" ..> "0..1 source" DatasetConcept : inherits / specialises
+DatasetConcept "*" --> "1" Dataset : member of
+Dataset "*" --> "*" Dataset : imports as building blocks
+DatasetConcept "*" --> "0..1" ValueSet : terminology binding (coded items)
+
+legend left
+  Cardinality + conformance live at BOTH levels:
+  - DatasetConcept = baseline (the general definition, shown in the dataset view)
+  - TransactionConcept = optional per-transaction restriction (shown in the transaction view)
+  --
+  Inheritance crosses datasets: a concept in a primary dataset inherits from a
+  concept in a building-block dataset. A zib is published as a building-block
+  Dataset; the inherited source concept carries the NL-CM id and drives the
+  FHIR / CDA representation. Inheritance is optional (query parameters have none).
+endlegend
+
+@enduml

--- a/input/images-source/authorization-model-evaluation.plantuml
+++ b/input/images-source/authorization-model-evaluation.plantuml
@@ -29,7 +29,6 @@ start
 :Receive AT request;
 note right
   **R**: transaction identifier (tx),
-  optional operations,
   asserted identity claims,
   context claims
 end note

--- a/input/images-source/authorization-model-evaluation.plantuml
+++ b/input/images-source/authorization-model-evaluation.plantuml
@@ -1,0 +1,110 @@
+' SPDX-FileCopyrightText: 2026 Steven van der Vegt
+'
+' SPDX-License-Identifier: CC-BY-SA-4.0
+
+@startuml authorization-model-evaluation
+
+skinparam defaultFontName Arial
+skinparam backgroundColor white
+skinparam roundcorner 10
+skinparam activity {
+  BackgroundColor #FFF2CC
+  BorderColor #D6B000
+}
+skinparam noteBackgroundColor #F8F8F8
+skinparam noteBorderColor #999999
+
+' Happy path. Any check failure results in rejection (not shown).
+
+legend top right
+  Input categories on each step:
+    **R**  Request inputs
+    **L1** Nictiz catalogue (layer 1)
+    **L2** Trust framework registry (layer 2)
+endlegend
+
+start
+
+:Receive AT request;
+note right
+  **R**: use-case scope token (uc),
+  requested operations,
+  asserted identity claims,
+  patient context
+end note
+
+:Look up UseCase by uc;
+note right
+  **L1**: UseCase catalogue
+end note
+
+:For each requested operation,
+identify the Transactiegroep and
+Transactie it belongs to;
+note right
+  **L1**: Transactiegroep,
+  Transactie, Operation catalogue
+  **R**: requested operations
+end note
+
+:Resolve required Systeemrol
+and Bedrijfsrol per operation;
+note right
+  **L1**: Transactie definition
+end note
+
+:Verify ServiceProvider's Qualifications
+cover every required Systeemrol;
+note right
+  **L2**: ServiceProvider Qualifications
+  Derived: required Systeemrollen
+end note
+
+:Verify ServiceProvider delegation
+authorizes every required Systeemrol;
+note right
+  **L2**: ServiceProvider delegation
+  Derived: required Systeemrollen
+end note
+
+:Verify HealthcareProfessional-to-
+HealthcareOrganization delegation
+authorizes every required Bedrijfsrol;
+note right
+  **L2**: HCP-to-HCO delegation
+  **R**: asserted HCP identity
+  Derived: required Bedrijfsrollen
+end note
+
+:Verify the asserted rolcode is
+permitted for every requested
+operation per the AuthorizationPolicy;
+note right
+  **L2**: AuthorizationPolicy
+  allowed_combinations
+  **R**: asserted rolcode
+  **R**: requested operations
+end note
+
+:Verify the asserted identity claims
+match the AuthenticationProfile
+required claims for the use case;
+note right
+  **R**: asserted identity claims
+  **L2**: AuthenticationProfile
+  required claim types
+end note
+
+:Mint AccessToken with uc claim,
+minted SoF scopes, carried claims,
+patient context;
+note right
+  **L1**: Operation -> Zib ->
+  FHIRResource (derives SoF scopes)
+end note
+
+:Return AccessToken;
+
+stop
+
+@enduml

--- a/input/images-source/authorization-model-evaluation.plantuml
+++ b/input/images-source/authorization-model-evaluation.plantuml
@@ -19,9 +19,9 @@ skinparam noteBorderColor #999999
 legend top right
   Input categories on each step:
     **R**  Request inputs
-    **L1** Nictiz catalogue (layer 1)
-    **L2** Trust framework registry (layer 2)
-    **L3** Realisation catalogue (interactietabel)
+    **L1** information layer (catalogue)
+    **L2** trust layer (registry)
+    **L3** realisation layer (interactietabel)
 endlegend
 
 start

--- a/input/images-source/authorization-model-evaluation.plantuml
+++ b/input/images-source/authorization-model-evaluation.plantuml
@@ -21,22 +21,23 @@ legend top right
     **R**  Request inputs
     **L1** Nictiz catalogue (layer 1)
     **L2** Trust framework registry (layer 2)
+    **L3** Realisation catalogue (interactietabel)
 endlegend
 
 start
 
 :Receive AT request;
 note right
-  **R**: transactie scope token (tx),
+  **R**: transaction scope token (tx),
   optional operations,
   asserted identity claims,
   context claims
 end note
 
-:Look up the Transactie by tx;
+:Look up the Transaction by tx;
 note right
-  **L1**: Transactie catalogue
-  (derives its Systeemrol and UseCase)
+  **L1**: Transaction catalogue
+  (derives its SystemRole and UseCase)
 end note
 
 :Resolve the AuthorizationRole:
@@ -44,24 +45,28 @@ a RolePrerequisite resolves the
 asserted identity claims;
 note right
   **L2**: RolePrerequisites
-  **R**: asserted rolcode and
+  **R**: asserted rolcode;
   HCP-to-HCO delegation
+  (under mandate only)
 end note
 
-:Resolve the Systeemrol:
-the SysteemrolPrerequisite resolves
-the ServiceProvider's claims;
+:Resolve the QualifiedSystemRole:
+the SystemRolePrerequisite resolves
+the ServiceProvider's claims and checks
+that it covers the Transaction;
 note right
-  **L2**: SysteemrolPrerequisite
+  **L2**: SystemRolePrerequisite,
+  QualifiedSystemRole coverage
   **R**: Qualification and
   ServiceProvider delegation
 end note
 
 :Check the PermissionMatrix permits
-(AuthorizationRole, Transactie);
+(AuthorizationRole, Transaction);
 note right
   **L2**: PermissionMatrix
-  allowed_combinations
+  (always present, may be trivial;
+  absent entry = deny)
 end note
 
 :Evaluate the use case's context gate;
@@ -71,12 +76,12 @@ note right
   (enrollment, consent, purpose)
 end note
 
-:Mint AccessToken with tx claim,
-minted SoF scopes, carried claims,
-patient context;
+:Mint AccessToken with the tx scope
+token, minted SoF scopes, carried
+claims, patient context;
 note right
-  **L1**: Operation -> Zib ->
-  FHIRResource (derives SoF scopes)
+  **L3**: Operation -> FHIR profile ->
+  resourceType (derives SoF scopes)
 end note
 
 :Return AccessToken;

--- a/input/images-source/authorization-model-evaluation.plantuml
+++ b/input/images-source/authorization-model-evaluation.plantuml
@@ -27,75 +27,51 @@ start
 
 :Receive AT request;
 note right
-  **R**: use-case scope token (uc),
-  requested operations,
+  **R**: transactie scope token (tx),
+  optional operations,
   asserted identity claims,
-  patient context
+  context claims
 end note
 
-:Look up UseCase by uc;
+:Look up the Transactie by tx;
 note right
-  **L1**: UseCase catalogue
+  **L1**: Transactie catalogue
+  (derives its Systeemrol and UseCase)
 end note
 
-:For each requested operation,
-identify the Transactiegroep and
-Transactie it belongs to;
+:Resolve the AuthorizationRole:
+a RolePrerequisite resolves the
+asserted identity claims;
 note right
-  **L1**: Transactiegroep,
-  Transactie, Operation catalogue
-  **R**: requested operations
+  **L2**: RolePrerequisites
+  **R**: asserted rolcode and
+  HCP-to-HCO delegation
 end note
 
-:Resolve required Systeemrol
-and Bedrijfsrol per operation;
+:Resolve the Systeemrol:
+the SysteemrolPrerequisite resolves
+the ServiceProvider's claims;
 note right
-  **L1**: Transactie definition
+  **L2**: SysteemrolPrerequisite
+  **R**: Qualification and
+  ServiceProvider delegation
 end note
 
-:Verify ServiceProvider's Qualifications
-cover every required Systeemrol;
+:Check the PermissionMatrix permits
+(AuthorizationRole, Transactie);
 note right
-  **L2**: ServiceProvider Qualifications
-  Derived: required Systeemrollen
-end note
-
-:Verify ServiceProvider delegation
-authorizes every required Systeemrol;
-note right
-  **L2**: ServiceProvider delegation
-  Derived: required Systeemrollen
-end note
-
-:Verify HealthcareProfessional-to-
-HealthcareOrganization delegation
-authorizes every required Bedrijfsrol;
-note right
-  **L2**: HCP-to-HCO delegation
-  **R**: asserted HCP identity
-  Derived: required Bedrijfsrollen
-end note
-
-:Verify the asserted rolcode is
-permitted for every requested
-operation per the AuthorizationPolicy;
-note right
-  **L2**: AuthorizationPolicy
+  **L2**: PermissionMatrix
   allowed_combinations
-  **R**: asserted rolcode
-  **R**: requested operations
 end note
 
-:Verify the asserted identity claims
-match the AuthenticationProfile
-required claims for the use case;
+:Evaluate the use case's context gate;
 note right
-  **R**: asserted identity claims
-  **L2**: AuthenticationProfile
-  required claim types
+  **L2**: required ContextClaims
+  **R**: asserted context claims
+  (enrollment, consent, purpose)
 end note
 
-:Mint AccessToken with uc claim,
+:Mint AccessToken with tx claim,
 minted SoF scopes, carried claims,
 patient context;
 note right

--- a/input/images-source/authorization-model-evaluation.plantuml
+++ b/input/images-source/authorization-model-evaluation.plantuml
@@ -28,7 +28,7 @@ start
 
 :Receive AT request;
 note right
-  **R**: transaction scope token (tx),
+  **R**: transaction identifier (tx),
   optional operations,
   asserted identity claims,
   context claims
@@ -69,16 +69,19 @@ note right
   absent entry = deny)
 end note
 
-:Evaluate the use case's context gate;
+:Evaluate the context checks
+declared for issuance;
 note right
-  **L2**: required ContextClaims
+  **L2**: context checks; each check's
+  enforcement point is declared
+  per use case
   **R**: asserted context claims
   (enrollment, consent, purpose)
 end note
 
-:Mint AccessToken with the tx scope
-token, minted SoF scopes, carried
-claims, patient context;
+:Issue AccessToken with the tx
+identifier, granted SoF scopes,
+carried claims, patient context;
 note right
   **L3**: Operation -> FHIR profile ->
   resourceType (derives SoF scopes)

--- a/input/images-source/authorization-model-layer2.plantuml
+++ b/input/images-source/authorization-model-layer2.plantuml
@@ -1,0 +1,108 @@
+' SPDX-FileCopyrightText: 2026 Steven van der Vegt
+'
+' SPDX-License-Identifier: CC-BY-SA-4.0
+
+@startuml authorization-model-layer2
+
+skinparam defaultFontName Arial
+skinparam backgroundColor white
+skinparam roundcorner 5
+skinparam classFontStyle bold
+skinparam classBackgroundColor #E1F5FE
+skinparam classBorderColor #0277BD
+hide circle
+
+' Nictiz-layer entities referenced from this diagram (yellow, layer 1)
+class UseCase <<Nictiz layer>> #FFF2CC ##D6B000 {
+  name
+}
+class Systeemrol <<Nictiz layer>> #FFF2CC ##D6B000 {
+  name
+}
+class Bedrijfsrol <<Nictiz layer>> #FFF2CC ##D6B000 {
+  name
+}
+
+' Governance
+class TrustFramework {
+  namespace
+  governance_authority
+}
+
+class AuthenticationProfile {
+  required_claim_types[]
+}
+
+class AuthorizationPolicy {
+  allowed_combinations[]
+}
+
+' Identity claims (abstract + concrete kinds)
+abstract class IdentityClaim {
+  type
+  value
+}
+
+class Qualification {
+  product
+  version
+}
+
+class HealthcareProfessionalDelegation {
+  authorizedBedrijfsrollen[]
+}
+
+class ServiceProviderDelegation {
+  authorizedSysteemrollen[]
+}
+
+' Actors
+class HealthcareProfessional {
+  identifier
+  rolcode
+}
+
+class HealthcareOrganization {
+  identifier
+  role_type
+}
+
+class ServiceProvider {
+  client_id
+}
+
+class Patient {
+  identifier (BSN)
+}
+
+' Governance relationships
+TrustFramework "1" --> "*" AuthenticationProfile : defines
+TrustFramework "1" --> "*" AuthorizationPolicy : defines
+TrustFramework "1" --> "*" IdentityClaim : defines vocabulary of
+
+AuthenticationProfile "1" --> "1" UseCase : profiles
+AuthorizationPolicy "1" --> "1" UseCase : for
+
+' Identity claim hierarchy: qualification and delegations are kinds of IdentityClaim
+Qualification -up-|> IdentityClaim
+HealthcareProfessionalDelegation -up-|> IdentityClaim
+ServiceProviderDelegation -up-|> IdentityClaim
+
+' Qualification: trust framework issues, service provider holds, concerns a systeemrol
+TrustFramework "1" --> "*" Qualification : issues
+ServiceProvider "1" --> "*" Qualification : holds
+Qualification "*" --> "1" Systeemrol : concerns
+
+' Delegation chain: HCP -> HCO (bedrijfsrol), HCO -> SP (systeemrol)
+HealthcareProfessional "1" --> "*" HealthcareProfessionalDelegation : issues
+HealthcareOrganization "1" --> "*" HealthcareProfessionalDelegation : receives
+HealthcareProfessionalDelegation "*" --> "*" Bedrijfsrol : authorizes
+
+HealthcareOrganization "1" --> "*" ServiceProviderDelegation : issues
+ServiceProvider "1" --> "*" ServiceProviderDelegation : receives
+ServiceProviderDelegation "*" --> "*" Systeemrol : authorizes
+
+HealthcareProfessional "*" --> "1" HealthcareOrganization : employed by
+HealthcareProfessional "*" --> "*" Patient : treats
+
+@enduml

--- a/input/images-source/authorization-model-layer2.plantuml
+++ b/input/images-source/authorization-model-layer2.plantuml
@@ -13,10 +13,10 @@ skinparam classBorderColor #0277BD
 hide circle
 
 ' === Layer 1 (Nictiz) roles the credentials concern/delegate - yellow ===
-class Systeemrol <<Nictiz layer>> #FFF2CC ##D6B000 {
+class SystemRole <<Nictiz layer>> #FFF2CC ##D6B000 {
   name
 }
-class Bedrijfsrol <<Nictiz layer>> #FFF2CC ##D6B000 {
+class BusinessRole <<Nictiz layer>> #FFF2CC ##D6B000 {
   name
 }
 
@@ -47,10 +47,15 @@ class Qualification #64B5F6 ##0D47A1 {
 }
 class HealthcareProfessionalDelegation #64B5F6 ##0D47A1
 class ServiceProviderDelegation #64B5F6 ##0D47A1
+class Membership #64B5F6 ##0D47A1 {
+  framework
+  information_standard [optional]
+}
 
 Qualification -up-|> IdentityClaim
 HealthcareProfessionalDelegation -up-|> IdentityClaim
 ServiceProviderDelegation -up-|> IdentityClaim
+Membership -up-|> IdentityClaim
 
 ' === Context claims (about the request and the patient) - mid-blue ===
 abstract class ContextClaim #64B5F6 ##0D47A1 {
@@ -61,18 +66,21 @@ class Enrollment #64B5F6 ##0D47A1
 
 Enrollment -up-|> ContextClaim
 
-' === Qualification: held by the service provider, certifies it for a systeemrol ===
+' === Qualification: held by the service provider, certifies it for a system role ===
 ServiceProvider "1" --> "*" Qualification : holds
-Qualification "*" --> "1" Systeemrol : certifies for
+Qualification "*" --> "1" SystemRole : certifies for
 
-' === Delegation chain: HCP -> HCO (bedrijfsrol), HCO -> SP (systeemrol) ===
+' === Membership: organisational admission to a framework / information standard ===
+HealthcareOrganization "1" --> "*" Membership : holds
+
+' === Delegation chain: HCP -> HCO (business role), HCO -> SP (system role) ===
 HealthcareProfessional "1" --> "*" HealthcareProfessionalDelegation : issues
 HealthcareOrganization "1" --> "*" HealthcareProfessionalDelegation : receives
-HealthcareProfessionalDelegation "*" --> "*" Bedrijfsrol : delegates
+HealthcareProfessionalDelegation "*" --> "*" BusinessRole : delegates
 
 HealthcareOrganization "1" --> "*" ServiceProviderDelegation : issues
 ServiceProvider "1" --> "*" ServiceProviderDelegation : receives
-ServiceProviderDelegation "*" --> "*" Systeemrol : delegates
+ServiceProviderDelegation "*" --> "*" SystemRole : delegates
 
 HealthcareProfessional "*" --> "1" HealthcareOrganization : employed by
 HealthcareProfessional "*" --> "*" Patient : enrolls/treats
@@ -81,5 +89,10 @@ HealthcareProfessional "*" --> "*" Patient : enrolls/treats
 HealthcareProfessional "1" --> "*" Enrollment : issues
 HealthcareOrganization "1" --> "*" Enrollment : receives
 Enrollment "*" --> "1" Patient : concerns
+
+' === Layout: credentials in one row so the IdentityClaim arrows run parallel (hidden, no semantics) ===
+Qualification -[hidden]right- HealthcareProfessionalDelegation
+HealthcareProfessionalDelegation -[hidden]right- ServiceProviderDelegation
+ServiceProviderDelegation -[hidden]right- Membership
 
 @enduml

--- a/input/images-source/authorization-model-layer2.plantuml
+++ b/input/images-source/authorization-model-layer2.plantuml
@@ -10,89 +10,74 @@ skinparam roundcorner 5
 skinparam classFontStyle bold
 skinparam classBackgroundColor #E1F5FE
 skinparam classBorderColor #0277BD
+skinparam nodesep 24
+skinparam ranksep 50
 hide circle
 
-' === Layer 1 (Nictiz) roles the credentials concern/delegate - yellow ===
-class SystemRole <<Nictiz layer>> #FFF2CC ##D6B000 {
-  name
-}
-class BusinessRole <<Nictiz layer>> #FFF2CC ##D6B000 {
-  name
-}
-
-' === Actors - pale blue ===
-class HealthcareProfessional {
-  identifier
-  rolcode
+' === Actors - pale blue (one row) ===
+class ServiceProvider {
+  client_id
 }
 class HealthcareOrganization {
   identifier
   role_type
 }
-class ServiceProvider {
-  client_id
+class HealthcareProfessional {
+  identifier
+  rolcode
 }
 class Patient {
   identifier (BSN)
 }
 
-' === Identity claims carried by credentials (about the requester) - mid-blue ===
-abstract class IdentityClaim #64B5F6 ##0D47A1 {
-  type
-  value
-}
-class Qualification #64B5F6 ##0D47A1 {
+' === Claims - mid-blue, typed by stereotype (one row below the actors) ===
+class Qualification <<IdentityClaim>> #64B5F6 ##0D47A1 {
   product
   version
 }
-class HealthcareProfessionalDelegation #64B5F6 ##0D47A1
-class ServiceProviderDelegation #64B5F6 ##0D47A1
-class Membership #64B5F6 ##0D47A1 {
+class ServiceProviderDelegation <<IdentityClaim>> #64B5F6 ##0D47A1
+class Membership <<IdentityClaim>> #64B5F6 ##0D47A1 {
   framework
   information_standard [optional]
 }
+class HealthcareProfessionalDelegation <<IdentityClaim>> #64B5F6 ##0D47A1
+class Enrollment <<ContextClaim>> #64B5F6 ##0D47A1
 
-Qualification -up-|> IdentityClaim
-HealthcareProfessionalDelegation -up-|> IdentityClaim
-ServiceProviderDelegation -up-|> IdentityClaim
-Membership -up-|> IdentityClaim
-
-' === Context claims (about the request and the patient) - mid-blue ===
-abstract class ContextClaim #64B5F6 ##0D47A1 {
-  type
-  value
+' === Information layer (L1) roles - yellow (bottom row) ===
+class SystemRole <<information layer>> #FFF2CC ##D6B000 {
+  name
 }
-class Enrollment #64B5F6 ##0D47A1
+class BusinessRole <<information layer>> #FFF2CC ##D6B000 {
+  name
+}
 
-Enrollment -up-|> ContextClaim
+' === Actor row relations (horizontal) ===
+ServiceProvider "*" -right-> "*" HealthcareOrganization : serves
+HealthcareProfessional "*" -left-> "1" HealthcareOrganization : employed by
+HealthcareProfessional "*" -right-> "*" Patient : enrolls/treats
 
-' === Qualification: held by the service provider, certifies it for a system role ===
-ServiceProvider "1" --> "*" Qualification : holds
-Qualification "*" --> "1" SystemRole : certifies for
+' === Actor -> claim (down) ===
+ServiceProvider "1" -down-> "*" Qualification : holds
+HealthcareOrganization "1" -down-> "*" ServiceProviderDelegation : issues
+ServiceProvider "1" -down-> "*" ServiceProviderDelegation : receives
+HealthcareOrganization "1" -down-> "*" Membership : holds
+HealthcareProfessional "1" -down-> "*" HealthcareProfessionalDelegation : issues
+HealthcareOrganization "1" -down-> "*" HealthcareProfessionalDelegation : receives
+HealthcareProfessional "1" -down-> "*" Enrollment : issues
+HealthcareOrganization "1" -down-> "*" Enrollment : receives
 
-' === Membership: organisational admission to a framework / information standard ===
-HealthcareOrganization "1" --> "*" Membership : holds
+' === Claim -> information layer role / patient ===
+Qualification "*" -down-> "1" SystemRole : certifies for
+ServiceProviderDelegation "*" -down-> "*" SystemRole : delegates
+HealthcareProfessionalDelegation "*" -down-> "*" BusinessRole : delegates
+Enrollment "*" -up-> "1" Patient : concerns
 
-' === Delegation chain: HCP -> HCO (business role), HCO -> SP (system role) ===
-HealthcareProfessional "1" --> "*" HealthcareProfessionalDelegation : issues
-HealthcareOrganization "1" --> "*" HealthcareProfessionalDelegation : receives
-HealthcareProfessionalDelegation "*" --> "*" BusinessRole : delegates
-
-HealthcareOrganization "1" --> "*" ServiceProviderDelegation : issues
-ServiceProvider "1" --> "*" ServiceProviderDelegation : receives
-ServiceProviderDelegation "*" --> "*" SystemRole : delegates
-
-HealthcareProfessional "*" --> "1" HealthcareOrganization : employed by
-HealthcareProfessional "*" --> "*" Patient : enrolls/treats
-
-' === Enrollment: the professional enrolls the patient at the organisation ===
-HealthcareProfessional "1" --> "*" Enrollment : issues
-HealthcareOrganization "1" --> "*" Enrollment : receives
-Enrollment "*" --> "1" Patient : concerns
-
-' === Layout: credentials in one row so the IdentityClaim arrows run parallel (hidden, no semantics) ===
-Qualification -[hidden]right- HealthcareProfessionalDelegation
-HealthcareProfessionalDelegation -[hidden]right- ServiceProviderDelegation
+' === Layout rows (hidden, no semantics) ===
+ServiceProvider -[hidden]right- HealthcareOrganization
+Qualification -[hidden]right- ServiceProviderDelegation
 ServiceProviderDelegation -[hidden]right- Membership
+Membership -[hidden]right- HealthcareProfessionalDelegation
+HealthcareProfessionalDelegation -[hidden]right- Enrollment
+SystemRole -[hidden]right- BusinessRole
 
 @enduml

--- a/input/images-source/authorization-model-layer2.plantuml
+++ b/input/images-source/authorization-model-layer2.plantuml
@@ -36,11 +36,19 @@ class Qualification <<IdentityClaim>> #64B5F6 ##0D47A1 {
   version
 }
 class ServiceProviderDelegation <<IdentityClaim>> #64B5F6 ##0D47A1
+class UserAssertion <<IdentityClaim>> #64B5F6 ##0D47A1 {
+  identifier
+  rolcode
+  session_validity
+}
 class Membership <<IdentityClaim>> #64B5F6 ##0D47A1 {
   framework
   information_standard [optional]
 }
-class HealthcareProfessionalDelegation <<IdentityClaim>> #64B5F6 ##0D47A1
+class HealthcareProfessionalDelegation <<IdentityClaim>> #64B5F6 ##0D47A1 {
+  identifier
+  rolcode
+}
 class Enrollment <<ContextClaim>> #64B5F6 ##0D47A1
 
 ' === Information layer (L1) roles - yellow (bottom row) ===
@@ -61,6 +69,8 @@ ServiceProvider "1" -down-> "*" Qualification : holds
 HealthcareOrganization "1" -down-> "*" ServiceProviderDelegation : issues
 ServiceProvider "1" -down-> "*" ServiceProviderDelegation : receives
 HealthcareOrganization "1" -down-> "*" Membership : holds
+HealthcareProfessional "1" -down-> "*" UserAssertion : issues
+ServiceProvider "1" -down-> "*" UserAssertion : receives
 HealthcareProfessional "1" -down-> "*" HealthcareProfessionalDelegation : issues
 HealthcareOrganization "1" -down-> "*" HealthcareProfessionalDelegation : receives
 HealthcareProfessional "1" -down-> "*" Enrollment : issues
@@ -76,7 +86,8 @@ Enrollment "*" -up-> "1" Patient : concerns
 ServiceProvider -[hidden]right- HealthcareOrganization
 Qualification -[hidden]right- ServiceProviderDelegation
 ServiceProviderDelegation -[hidden]right- Membership
-Membership -[hidden]right- HealthcareProfessionalDelegation
+Membership -[hidden]right- UserAssertion
+UserAssertion -[hidden]right- HealthcareProfessionalDelegation
 HealthcareProfessionalDelegation -[hidden]right- Enrollment
 SystemRole -[hidden]right- BusinessRole
 

--- a/input/images-source/authorization-model-layer2.plantuml
+++ b/input/images-source/authorization-model-layer2.plantuml
@@ -12,10 +12,7 @@ skinparam classBackgroundColor #E1F5FE
 skinparam classBorderColor #0277BD
 hide circle
 
-' Nictiz-layer entities referenced from this diagram (yellow, layer 1)
-class UseCase <<Nictiz layer>> #FFF2CC ##D6B000 {
-  name
-}
+' === Layer 1 (Nictiz) roles the credentials concern/delegate - yellow ===
 class Systeemrol <<Nictiz layer>> #FFF2CC ##D6B000 {
   name
 }
@@ -23,86 +20,66 @@ class Bedrijfsrol <<Nictiz layer>> #FFF2CC ##D6B000 {
   name
 }
 
-' Governance
-class TrustFramework {
-  namespace
-  governance_authority
-}
-
-class AuthenticationProfile {
-  required_claim_types[]
-}
-
-class AuthorizationPolicy {
-  allowed_combinations[]
-}
-
-' Identity claims (abstract + concrete kinds)
-abstract class IdentityClaim {
-  type
-  value
-}
-
-class Qualification {
-  product
-  version
-}
-
-class HealthcareProfessionalDelegation {
-  authorizedBedrijfsrollen[]
-}
-
-class ServiceProviderDelegation {
-  authorizedSysteemrollen[]
-}
-
-' Actors
+' === Actors - pale blue ===
 class HealthcareProfessional {
   identifier
   rolcode
 }
-
 class HealthcareOrganization {
   identifier
   role_type
 }
-
 class ServiceProvider {
   client_id
 }
-
 class Patient {
   identifier (BSN)
 }
 
-' Governance relationships
-TrustFramework "1" --> "*" AuthenticationProfile : defines
-TrustFramework "1" --> "*" AuthorizationPolicy : defines
-TrustFramework "1" --> "*" IdentityClaim : defines vocabulary of
+' === Identity claims carried by credentials (about the requester) - mid-blue ===
+abstract class IdentityClaim #64B5F6 ##0D47A1 {
+  type
+  value
+}
+class Qualification #64B5F6 ##0D47A1 {
+  product
+  version
+}
+class HealthcareProfessionalDelegation #64B5F6 ##0D47A1
+class ServiceProviderDelegation #64B5F6 ##0D47A1
 
-AuthenticationProfile "1" --> "1" UseCase : profiles
-AuthorizationPolicy "1" --> "1" UseCase : for
-
-' Identity claim hierarchy: qualification and delegations are kinds of IdentityClaim
 Qualification -up-|> IdentityClaim
 HealthcareProfessionalDelegation -up-|> IdentityClaim
 ServiceProviderDelegation -up-|> IdentityClaim
 
-' Qualification: trust framework issues, service provider holds, concerns a systeemrol
-TrustFramework "1" --> "*" Qualification : issues
-ServiceProvider "1" --> "*" Qualification : holds
-Qualification "*" --> "1" Systeemrol : concerns
+' === Context claims (about the request and the patient) - mid-blue ===
+abstract class ContextClaim #64B5F6 ##0D47A1 {
+  type
+  value
+}
+class Enrollment #64B5F6 ##0D47A1
 
-' Delegation chain: HCP -> HCO (bedrijfsrol), HCO -> SP (systeemrol)
+Enrollment -up-|> ContextClaim
+
+' === Qualification: held by the service provider, certifies it for a systeemrol ===
+ServiceProvider "1" --> "*" Qualification : holds
+Qualification "*" --> "1" Systeemrol : certifies for
+
+' === Delegation chain: HCP -> HCO (bedrijfsrol), HCO -> SP (systeemrol) ===
 HealthcareProfessional "1" --> "*" HealthcareProfessionalDelegation : issues
 HealthcareOrganization "1" --> "*" HealthcareProfessionalDelegation : receives
-HealthcareProfessionalDelegation "*" --> "*" Bedrijfsrol : authorizes
+HealthcareProfessionalDelegation "*" --> "*" Bedrijfsrol : delegates
 
 HealthcareOrganization "1" --> "*" ServiceProviderDelegation : issues
 ServiceProvider "1" --> "*" ServiceProviderDelegation : receives
-ServiceProviderDelegation "*" --> "*" Systeemrol : authorizes
+ServiceProviderDelegation "*" --> "*" Systeemrol : delegates
 
 HealthcareProfessional "*" --> "1" HealthcareOrganization : employed by
-HealthcareProfessional "*" --> "*" Patient : treats
+HealthcareProfessional "*" --> "*" Patient : enrolls/treats
+
+' === Enrollment: the professional enrolls the patient at the organisation ===
+HealthcareProfessional "1" --> "*" Enrollment : issues
+HealthcareOrganization "1" --> "*" Enrollment : receives
+Enrollment "*" --> "1" Patient : concerns
 
 @enduml

--- a/input/images-source/authorization-model-layer3.plantuml
+++ b/input/images-source/authorization-model-layer3.plantuml
@@ -13,7 +13,7 @@ skinparam classBorderColor #2E7D32
 hide circle
 
 ' Layer 1 (Nictiz) entities referenced from this diagram (yellow)
-class UseCase <<Nictiz layer>> #FFF2CC ##D6B000 {
+class Transactie <<Nictiz layer>> #FFF2CC ##D6B000 {
   name
 }
 class Operation <<Nictiz layer>> #FFF2CC ##D6B000 {
@@ -36,14 +36,14 @@ class ServiceProvider <<Layer 2>> #E1F5FE ##0277BD {
 
 ' Layer 3: OAuth wire artefacts
 class AccessTokenRequest {
-  uc
+  tx
   operations[]
   asserted_claims[]
   patient
 }
 
 class AccessToken {
-  uc
+  tx
   scope[]
   patient
   claims[]
@@ -57,13 +57,13 @@ class SoFScope {
 
 ' AT request: what the ServiceProvider sends to the AS
 ServiceProvider "1" --> "*" AccessTokenRequest : sends
-AccessTokenRequest "*" --> "1" UseCase : names
-AccessTokenRequest "*" --> "*" Operation : requests
+AccessTokenRequest "*" --> "1" Transactie : names
+AccessTokenRequest "*" --> "*" Operation : narrows (optional)
 AccessTokenRequest "*" --> "*" IdentityClaim : asserts
 
 ' AT issued: what the AS returns on success
 AccessTokenRequest "1" ..> "1" AccessToken : results in (if approved)
-AccessToken "1" --> "1" UseCase : authorizes
+AccessToken "1" --> "1" Transactie : authorizes
 AccessToken "1" --> "*" IdentityClaim : carries
 AccessToken "1" --> "*" SoFScope : carries
 SoFScope "*" --> "1" FHIRResource : resource references

--- a/input/images-source/authorization-model-layer3.plantuml
+++ b/input/images-source/authorization-model-layer3.plantuml
@@ -13,13 +13,13 @@ skinparam classBorderColor #2E7D32
 hide circle
 
 ' Layer 1 (Nictiz) entities referenced from this diagram (yellow)
-class Transaction <<Nictiz layer>> #FFF2CC ##D6B000 {
+class Transaction <<information layer>> #FFF2CC ##D6B000 {
   name
 }
 
-' Layer 3 realisation entities (green, like the OAuth artefacts):
-' the Operation is the AORTA interactietabel interactionId, not a
-' Nictiz layer-1 concept; FHIRResource is its FHIR realisation target.
+' Realisation-layer entities (green, like the OAuth artefacts):
+' the Operation is the AORTA interactietabel interactionId, not an
+' information-layer concept; FHIRResource is its FHIR realisation target.
 class Operation <<interactietabel>> {
   verb
   artifact
@@ -30,11 +30,11 @@ class FHIRResource <<FHIR>> {
 }
 
 ' Layer 2 entities referenced from this diagram (blue)
-abstract class IdentityClaim <<Layer 2>> #E1F5FE ##0277BD {
+abstract class IdentityClaim <<trust layer>> #E1F5FE ##0277BD {
   type
   value
 }
-class ServiceProvider <<Layer 2>> #E1F5FE ##0277BD {
+class ServiceProvider <<trust layer>> #E1F5FE ##0277BD {
   client_id
 }
 

--- a/input/images-source/authorization-model-layer3.plantuml
+++ b/input/images-source/authorization-model-layer3.plantuml
@@ -13,15 +13,19 @@ skinparam classBorderColor #2E7D32
 hide circle
 
 ' Layer 1 (Nictiz) entities referenced from this diagram (yellow)
-class Transactie <<Nictiz layer>> #FFF2CC ##D6B000 {
+class Transaction <<Nictiz layer>> #FFF2CC ##D6B000 {
   name
 }
-class Operation <<Nictiz layer>> #FFF2CC ##D6B000 {
+
+' Layer 3 realisation entities (green, like the OAuth artefacts):
+' the Operation is the AORTA interactietabel interactionId, not a
+' Nictiz layer-1 concept; FHIRResource is its FHIR realisation target.
+class Operation <<interactietabel>> {
   verb
   artifact
   version
 }
-class FHIRResource <<Nictiz layer>> #FFF2CC ##D6B000 {
+class FHIRResource <<FHIR>> {
   resourceType
 }
 
@@ -43,8 +47,7 @@ class AccessTokenRequest {
 }
 
 class AccessToken {
-  tx
-  scope[]
+  scope[]  [incl. tx token]
   patient
   claims[]
 }
@@ -55,15 +58,19 @@ class SoFScope {
   crud
 }
 
+' Realisation: operations are reusable wire-level building blocks
+Operation "*" --> "*" Transaction : realises
+Operation "*" --> "1" FHIRResource : targets (fhir.resourceType)
+
 ' AT request: what the ServiceProvider sends to the AS
 ServiceProvider "1" --> "*" AccessTokenRequest : sends
-AccessTokenRequest "*" --> "1" Transactie : names
+AccessTokenRequest "*" --> "1" Transaction : names
 AccessTokenRequest "*" --> "*" Operation : narrows (optional)
 AccessTokenRequest "*" --> "*" IdentityClaim : asserts
 
 ' AT issued: what the AS returns on success
 AccessTokenRequest "1" ..> "1" AccessToken : results in (if approved)
-AccessToken "1" --> "1" Transactie : authorizes
+AccessToken "1" --> "1" Transaction : authorizes
 AccessToken "1" --> "*" IdentityClaim : carries
 AccessToken "1" --> "*" SoFScope : carries
 SoFScope "*" --> "1" FHIRResource : resource references

--- a/input/images-source/authorization-model-layer3.plantuml
+++ b/input/images-source/authorization-model-layer3.plantuml
@@ -10,6 +10,8 @@ skinparam roundcorner 5
 skinparam classFontStyle bold
 skinparam classBackgroundColor #E8F5E9
 skinparam classBorderColor #2E7D32
+skinparam nodesep 24
+skinparam ranksep 50
 hide circle
 
 ' Layer 1 (Nictiz) entities referenced from this diagram (yellow)
@@ -41,13 +43,12 @@ class ServiceProvider <<trust layer>> #E1F5FE ##0277BD {
 ' Layer 3: OAuth wire artefacts
 class AccessTokenRequest {
   tx
-  operations[]
   asserted_claims[]
   patient
 }
 
 class AccessToken {
-  scope[]  [incl. tx token]
+  scope[]  [incl. tx identifier]
   patient
   claims[]
 }
@@ -58,21 +59,25 @@ class SoFScope {
   crud
 }
 
-' Realisation: operations are reusable wire-level building blocks
-Operation "*" --> "*" Transaction : realises
-Operation "*" --> "1" FHIRResource : targets (fhir.resourceType)
+' === Wire-artefact row relations (horizontal, top row) ===
+ServiceProvider "1" -right-> "*" AccessTokenRequest : sends
+AccessTokenRequest "1" .right.> "1" AccessToken : results in (if approved)
+AccessToken "1" -right-> "*" SoFScope : carries
 
-' AT request: what the ServiceProvider sends to the AS
-ServiceProvider "1" --> "*" AccessTokenRequest : sends
-AccessTokenRequest "*" --> "1" Transaction : names
-AccessTokenRequest "*" --> "*" Operation : narrows (optional)
-AccessTokenRequest "*" --> "*" IdentityClaim : asserts
+' === Wire artefact -> referenced entity (down) ===
+AccessTokenRequest "*" -down-> "*" IdentityClaim : asserts
+AccessTokenRequest "*" -down-> "1" Transaction : names
+AccessToken "1" -down-> "*" IdentityClaim : carries
+AccessToken "1" -down-> "1" Transaction : authorizes
+SoFScope "*" -down-> "1" Operation : derived from
+SoFScope "*" -down-> "1" FHIRResource : resource references
 
-' AT issued: what the AS returns on success
-AccessTokenRequest "1" ..> "1" AccessToken : results in (if approved)
-AccessToken "1" --> "1" Transaction : authorizes
-AccessToken "1" --> "*" IdentityClaim : carries
-AccessToken "1" --> "*" SoFScope : carries
-SoFScope "*" --> "1" FHIRResource : resource references
+' === Catalogue row relations (horizontal, bottom row) ===
+' Realisation: operations are reusable realisation building blocks
+Operation "*" -left-> "*" Transaction : realises
+Operation "*" -right-> "1" FHIRResource : targets (fhir.resourceType)
+
+' === Layout rows (hidden, no semantics) ===
+IdentityClaim -[hidden]right- Transaction
 
 @enduml

--- a/input/images-source/authorization-model-layer3.plantuml
+++ b/input/images-source/authorization-model-layer3.plantuml
@@ -1,0 +1,71 @@
+' SPDX-FileCopyrightText: 2026 Steven van der Vegt
+'
+' SPDX-License-Identifier: CC-BY-SA-4.0
+
+@startuml authorization-model-layer3
+
+skinparam defaultFontName Arial
+skinparam backgroundColor white
+skinparam roundcorner 5
+skinparam classFontStyle bold
+skinparam classBackgroundColor #E8F5E9
+skinparam classBorderColor #2E7D32
+hide circle
+
+' Layer 1 (Nictiz) entities referenced from this diagram (yellow)
+class UseCase <<Nictiz layer>> #FFF2CC ##D6B000 {
+  name
+}
+class Operation <<Nictiz layer>> #FFF2CC ##D6B000 {
+  verb
+  artifact
+  version
+}
+class FHIRResource <<Nictiz layer>> #FFF2CC ##D6B000 {
+  resourceType
+}
+
+' Layer 2 entities referenced from this diagram (blue)
+abstract class IdentityClaim <<Layer 2>> #E1F5FE ##0277BD {
+  type
+  value
+}
+class ServiceProvider <<Layer 2>> #E1F5FE ##0277BD {
+  client_id
+}
+
+' Layer 3: OAuth wire artefacts
+class AccessTokenRequest {
+  uc
+  operations[]
+  asserted_claims[]
+  patient
+}
+
+class AccessToken {
+  uc
+  scope[]
+  patient
+  claims[]
+}
+
+class SoFScope {
+  context
+  resource
+  crud
+}
+
+' AT request: what the ServiceProvider sends to the AS
+ServiceProvider "1" --> "*" AccessTokenRequest : sends
+AccessTokenRequest "*" --> "1" UseCase : names
+AccessTokenRequest "*" --> "*" Operation : requests
+AccessTokenRequest "*" --> "*" IdentityClaim : asserts
+
+' AT issued: what the AS returns on success
+AccessTokenRequest "1" ..> "1" AccessToken : results in (if approved)
+AccessToken "1" --> "1" UseCase : authorizes
+AccessToken "1" --> "*" IdentityClaim : carries
+AccessToken "1" --> "*" SoFScope : carries
+SoFScope "*" --> "1" FHIRResource : resource references
+
+@enduml

--- a/input/images-source/authorization-model-nictiz.plantuml
+++ b/input/images-source/authorization-model-nictiz.plantuml
@@ -1,0 +1,67 @@
+' SPDX-FileCopyrightText: 2026 Steven van der Vegt
+'
+' SPDX-License-Identifier: CC-BY-SA-4.0
+
+@startuml authorization-model-nictiz
+
+skinparam defaultFontName Arial
+skinparam backgroundColor white
+skinparam roundcorner 5
+skinparam classBackgroundColor #FFF2CC
+skinparam classBorderColor #D6B000
+skinparam classFontStyle bold
+hide circle
+
+class Informatiestandaard {
+  name
+  version
+}
+
+class UseCase {
+  name
+}
+
+class Transactiegroep {
+  name
+  direction
+}
+
+class Transactie {
+  name
+  FHIR_or_CDA_profiles
+}
+
+class Operation {
+  verb
+  artifact
+  version
+}
+
+class Systeemrol {
+  name
+  type
+}
+
+class Bedrijfsrol {
+  name
+}
+
+class Zib {
+  name
+  version
+}
+
+class FHIRResource {
+  resourceType
+}
+
+Informatiestandaard "1" --> "*" UseCase : contains
+UseCase "1" --> "*" Transactiegroep : groups
+Transactiegroep "1" --> "*" Transactie : composed of
+Transactie "1" --> "*" Operation : decomposes into
+Transactie "1" --> "2" Systeemrol : exchanges between
+Transactie "*" --> "*" Bedrijfsrol : performed by
+Operation "*" --> "1..*" Zib : artifact references
+Zib "1" --> "1..*" FHIRResource : profiles
+
+@enduml

--- a/input/images-source/authorization-model-nictiz.plantuml
+++ b/input/images-source/authorization-model-nictiz.plantuml
@@ -12,11 +12,22 @@ skinparam classBorderColor #D6B000
 skinparam classFontStyle bold
 hide circle
 
-title Layer 1: Nictiz information-standard model (functional core)
+title Information layer (L1): the Nictiz information-standard model (functional core)
 
 class InformationStandard {
   name
   version
+}
+class Dataset {
+  name
+  version
+}
+class DatasetConcept {
+  name
+  type : group | item
+  valueDomain  [item only]
+  conformance  [baseline]
+  cardinality  [baseline]
 }
 class UseCase {
   name
@@ -30,41 +41,29 @@ class Transaction {
   version
   type : initial | back | stationary
 }
+class BusinessRole {
+  name
+}
 class SystemRole {
   name
   kind
 }
-class BusinessRole {
-  name
-}
-class Dataset {
-  name
-  version
-}
-class DatasetConcept {
-  name
-  type : group | item
-  valueDomain  [item only]
-  conformance  [baseline]
-  cardinality  [baseline]
-}
 
-InformationStandard "1" --> "*" UseCase : contains
-InformationStandard "1" --> "*" Dataset : defines (primary)
-UseCase "1" --> "*" TransactionGroup : groups
-TransactionGroup "1" --> "*" Transaction : composed of
-Transaction "*" --> "0..*" SystemRole : involves (sender / receiver)
-Transaction "*" --> "*" BusinessRole : performed by
-Transaction "*" --> "*" DatasetConcept : selects + profiles
+InformationStandard "1" -down-> "*" Dataset : defines (primary)
+InformationStandard "1" -down-> "*" UseCase : contains
+DatasetConcept "*" -up-> "1" Dataset : member of
+UseCase "1" -down-> "*" TransactionGroup : groups
+TransactionGroup "1" -down-> "*" Transaction : composed of
+Transaction "*" -up-> "*" DatasetConcept : selects + profiles
 DatasetConcept "group 1" o-- "*" DatasetConcept : contains (concept tree)
-DatasetConcept "*" --> "1" Dataset : member of
+Transaction "*" -down-> "*" BusinessRole : performed by
+Transaction "*" -down-> "0..*" SystemRole : involves (sender / receiver)
 
 note bottom of DatasetConcept
-  "selects + profiles" = the transaction dataset:
+  "selects + profiles" the transaction dataset:
   the transaction picks a subset and restricts each
   concept's baseline conformance / cardinality.
-  (Building-block / zib inheritance and the FHIR/CDA
-  representation are omitted here.)
+  Dataset details are omitted here for brevity.
 end note
 
 @enduml

--- a/input/images-source/authorization-model-nictiz.plantuml
+++ b/input/images-source/authorization-model-nictiz.plantuml
@@ -12,56 +12,59 @@ skinparam classBorderColor #D6B000
 skinparam classFontStyle bold
 hide circle
 
-class Informatiestandaard {
+title Layer 1: Nictiz information-standard model (functional core)
+
+class InformationStandard {
   name
   version
 }
-
 class UseCase {
   name
-}
-
-class Transactiegroep {
-  name
-  direction
-}
-
-class Transactie {
-  name
-  FHIR_or_CDA_profiles
-}
-
-class Operation {
-  verb
-  artifact
   version
 }
-
-class Systeemrol {
-  name
-  type
-}
-
-class Bedrijfsrol {
+class TransactionGroup {
   name
 }
-
-class Zib {
+class Transaction {
+  name
+  version
+  type : initial | back | stationary
+}
+class SystemRole {
+  name
+  kind
+}
+class BusinessRole {
+  name
+}
+class Dataset {
   name
   version
 }
-
-class FHIRResource {
-  resourceType
+class DatasetConcept {
+  name
+  type : group | item
+  valueDomain  [item only]
+  conformance  [baseline]
+  cardinality  [baseline]
 }
 
-Informatiestandaard "1" --> "*" UseCase : contains
-UseCase "1" --> "*" Transactiegroep : groups
-Transactiegroep "1" --> "*" Transactie : composed of
-Transactie "*" --> "*" Operation : uses
-Transactie "1" --> "2" Systeemrol : exchanges between
-Transactie "*" --> "*" Bedrijfsrol : performed by
-Operation "*" --> "1..*" Zib : artifact references
-Zib "1" --> "1..*" FHIRResource : profiles
+InformationStandard "1" --> "*" UseCase : contains
+InformationStandard "1" --> "*" Dataset : defines (primary)
+UseCase "1" --> "*" TransactionGroup : groups
+TransactionGroup "1" --> "*" Transaction : composed of
+Transaction "*" --> "0..*" SystemRole : involves (sender / receiver)
+Transaction "*" --> "*" BusinessRole : performed by
+Transaction "*" --> "*" DatasetConcept : selects + profiles
+DatasetConcept "group 1" o-- "*" DatasetConcept : contains (concept tree)
+DatasetConcept "*" --> "1" Dataset : member of
+
+note bottom of DatasetConcept
+  "selects + profiles" = the transaction dataset:
+  the transaction picks a subset and restricts each
+  concept's baseline conformance / cardinality.
+  (Building-block / zib inheritance and the FHIR/CDA
+  representation are omitted here.)
+end note
 
 @enduml

--- a/input/images-source/authorization-model-nictiz.plantuml
+++ b/input/images-source/authorization-model-nictiz.plantuml
@@ -58,7 +58,7 @@ class FHIRResource {
 Informatiestandaard "1" --> "*" UseCase : contains
 UseCase "1" --> "*" Transactiegroep : groups
 Transactiegroep "1" --> "*" Transactie : composed of
-Transactie "1" --> "*" Operation : decomposes into
+Transactie "*" --> "*" Operation : uses
 Transactie "1" --> "2" Systeemrol : exchanges between
 Transactie "*" --> "*" Bedrijfsrol : performed by
 Operation "*" --> "1..*" Zib : artifact references

--- a/input/images-source/authorization-model-role-resolution.plantuml
+++ b/input/images-source/authorization-model-role-resolution.plantuml
@@ -1,0 +1,68 @@
+' SPDX-FileCopyrightText: 2026 Steven van der Vegt
+'
+' SPDX-License-Identifier: CC-BY-SA-4.0
+
+@startuml authorization-model-role-resolution
+
+skinparam defaultFontName Arial
+skinparam backgroundColor white
+skinparam roundcorner 5
+skinparam classFontStyle bold
+skinparam classBackgroundColor #E1F5FE
+skinparam classBorderColor #0277BD
+hide circle
+
+' === Layer 1 (Nictiz catalogue) - yellow ===
+class UseCase <<Nictiz layer>> #FFF2CC ##D6B000 {
+  name
+}
+class Transactiegroep <<Nictiz layer>> #FFF2CC ##D6B000 {
+  name
+}
+class Transactie <<Nictiz layer>> #FFF2CC ##D6B000 {
+  name
+  direction
+}
+class Bedrijfsrol <<Nictiz layer>> #FFF2CC ##D6B000 {
+  name
+}
+class Systeemrol <<Nictiz layer>> #FFF2CC ##D6B000 {
+  name
+  type
+}
+
+' === Layer 2: framework role resolution + policy - blue ===
+class RolePrerequisite
+class AuthorizationRole {
+  name
+}
+class PermissionMatrix {
+  allowed_combinations[]
+}
+class SysteemrolPrerequisite
+
+' === Layer 2: claim vocabulary - mid-blue ===
+class IdentityClaim #64B5F6 ##0D47A1
+class ContextClaim #64B5F6 ##0D47A1
+
+' === Catalogue: a Transactie belongs to one UseCase; it couples both role kinds ===
+UseCase "1" --> "*" Transactiegroep : groups
+Transactiegroep "1" --> "*" Transactie : per direction
+Transactie "*" --> "*" Bedrijfsrol : performed by
+Transactie "1" --> "2" Systeemrol : exchanges between
+
+' === Use-case context gate (intent: consent, treatment relationship, purpose) ===
+UseCase "1" --> "*" ContextClaim : context gate
+
+' === Professional side: claims -> RolePrerequisite (OR) -> AuthorizationRole -> matrix ===
+RolePrerequisite "*" --> "1" AuthorizationRole : resolves to
+RolePrerequisite "1" --> "*" IdentityClaim : requires
+AuthorizationRole "*" --> "1" Bedrijfsrol : refines
+PermissionMatrix "1" --> "*" AuthorizationRole : permits
+PermissionMatrix "1" --> "*" Transactie : for
+
+' === System side: claims -> SysteemrolPrerequisite (OR) -> Systeemrol (no matrix) ===
+SysteemrolPrerequisite "*" --> "1" Systeemrol : resolves to
+SysteemrolPrerequisite "1" --> "*" IdentityClaim : requires
+
+@enduml

--- a/input/images-source/authorization-model-role-resolution.plantuml
+++ b/input/images-source/authorization-model-role-resolution.plantuml
@@ -19,7 +19,7 @@ title Role resolution and permission: two parallel pipelines
 ' === Shared input: the presented claims (mid-blue) ===
 class IdentityClaim #64B5F6 ##0D47A1
 
-' === Professional pipeline (left) ===
+' === Business-role pipeline (left) ===
 class RolePrerequisite
 class AuthorizationRole {
   name
@@ -28,31 +28,31 @@ class PermissionMatrix {
   allowed_combinations[]
 }
 
-' === System pipeline (right) ===
+' === System-role pipeline (right) ===
 class SystemRolePrerequisite
 class QualifiedSystemRole {
   name
 }
 
 ' === Layer 1 (Nictiz catalogue) - yellow ===
-class Transaction <<Nictiz layer>> #FFF2CC ##D6B000 {
+class Transaction <<information layer>> #FFF2CC ##D6B000 {
   name
 }
-class BusinessRole <<Nictiz layer>> #FFF2CC ##D6B000 {
+class BusinessRole <<information layer>> #FFF2CC ##D6B000 {
   name
 }
-class SystemRole <<Nictiz layer>> #FFF2CC ##D6B000 {
+class SystemRole <<information layer>> #FFF2CC ##D6B000 {
   name
 }
 
-' === Professional side: claims -> RolePrerequisite (OR) -> AuthorizationRole -> matrix ===
+' === Business-role side: claims -> RolePrerequisite (OR) -> AuthorizationRole -> matrix ===
 RolePrerequisite "*" -up-> "*" IdentityClaim : requires
 RolePrerequisite "*" --> "1" AuthorizationRole : resolves to
 AuthorizationRole "*" --> "1" BusinessRole : refines
 PermissionMatrix "1" -up-> "*" AuthorizationRole : permits
 PermissionMatrix "1" --> "*" Transaction : for
 
-' === System side: claims -> SystemRolePrerequisite (OR) -> QualifiedSystemRole (no matrix) ===
+' === System-role side: claims -> SystemRolePrerequisite (OR) -> QualifiedSystemRole (no matrix) ===
 SystemRolePrerequisite "*" -up-> "*" IdentityClaim : requires
 SystemRolePrerequisite "*" --> "1" QualifiedSystemRole : resolves to
 QualifiedSystemRole "*" --> "1" SystemRole : refines

--- a/input/images-source/authorization-model-role-resolution.plantuml
+++ b/input/images-source/authorization-model-role-resolution.plantuml
@@ -10,28 +10,16 @@ skinparam roundcorner 5
 skinparam classFontStyle bold
 skinparam classBackgroundColor #E1F5FE
 skinparam classBorderColor #0277BD
+skinparam nodesep 30
+skinparam ranksep 40
 hide circle
 
-' === Layer 1 (Nictiz catalogue) - yellow ===
-class UseCase <<Nictiz layer>> #FFF2CC ##D6B000 {
-  name
-}
-class Transactiegroep <<Nictiz layer>> #FFF2CC ##D6B000 {
-  name
-}
-class Transactie <<Nictiz layer>> #FFF2CC ##D6B000 {
-  name
-  direction
-}
-class Bedrijfsrol <<Nictiz layer>> #FFF2CC ##D6B000 {
-  name
-}
-class Systeemrol <<Nictiz layer>> #FFF2CC ##D6B000 {
-  name
-  type
-}
+title Role resolution and permission: two parallel pipelines
 
-' === Layer 2: framework role resolution + policy - blue ===
+' === Shared input: the presented claims (mid-blue) ===
+class IdentityClaim #64B5F6 ##0D47A1
+
+' === Professional pipeline (left) ===
 class RolePrerequisite
 class AuthorizationRole {
   name
@@ -39,30 +27,44 @@ class AuthorizationRole {
 class PermissionMatrix {
   allowed_combinations[]
 }
-class SysteemrolPrerequisite
 
-' === Layer 2: claim vocabulary - mid-blue ===
-class IdentityClaim #64B5F6 ##0D47A1
-class ContextClaim #64B5F6 ##0D47A1
+' === System pipeline (right) ===
+class SystemRolePrerequisite
+class QualifiedSystemRole {
+  name
+}
 
-' === Catalogue: a Transactie belongs to one UseCase; it couples both role kinds ===
-UseCase "1" --> "*" Transactiegroep : groups
-Transactiegroep "1" --> "*" Transactie : per direction
-Transactie "*" --> "*" Bedrijfsrol : performed by
-Transactie "1" --> "2" Systeemrol : exchanges between
-
-' === Use-case context gate (intent: consent, treatment relationship, purpose) ===
-UseCase "1" --> "*" ContextClaim : context gate
+' === Layer 1 (Nictiz catalogue) - yellow ===
+class Transaction <<Nictiz layer>> #FFF2CC ##D6B000 {
+  name
+}
+class BusinessRole <<Nictiz layer>> #FFF2CC ##D6B000 {
+  name
+}
+class SystemRole <<Nictiz layer>> #FFF2CC ##D6B000 {
+  name
+}
 
 ' === Professional side: claims -> RolePrerequisite (OR) -> AuthorizationRole -> matrix ===
+RolePrerequisite "*" -up-> "*" IdentityClaim : requires
 RolePrerequisite "*" --> "1" AuthorizationRole : resolves to
-RolePrerequisite "1" --> "*" IdentityClaim : requires
-AuthorizationRole "*" --> "1" Bedrijfsrol : refines
-PermissionMatrix "1" --> "*" AuthorizationRole : permits
-PermissionMatrix "1" --> "*" Transactie : for
+AuthorizationRole "*" --> "1" BusinessRole : refines
+PermissionMatrix "1" -up-> "*" AuthorizationRole : permits
+PermissionMatrix "1" --> "*" Transaction : for
 
-' === System side: claims -> SysteemrolPrerequisite (OR) -> Systeemrol (no matrix) ===
-SysteemrolPrerequisite "*" --> "1" Systeemrol : resolves to
-SysteemrolPrerequisite "1" --> "*" IdentityClaim : requires
+' === System side: claims -> SystemRolePrerequisite (OR) -> QualifiedSystemRole (no matrix) ===
+SystemRolePrerequisite "*" -up-> "*" IdentityClaim : requires
+SystemRolePrerequisite "*" --> "1" QualifiedSystemRole : resolves to
+QualifiedSystemRole "*" --> "1" SystemRole : refines
+QualifiedSystemRole "*" --> "1..*" Transaction : permits
+
+' === Catalogue coupling at the bottom ===
+Transaction "*" -left-> "*" BusinessRole : performed by
+Transaction "*" -right-> "0..*" SystemRole : involves
+
+' === Layout: two columns meeting at Transaction (hidden, no semantics) ===
+RolePrerequisite -[hidden]right- SystemRolePrerequisite
+AuthorizationRole -[hidden]right- QualifiedSystemRole
+PermissionMatrix -[hidden]right- Transaction
 
 @enduml

--- a/input/pagecontent/authorization-model.md
+++ b/input/pagecontent/authorization-model.md
@@ -32,8 +32,8 @@ Hierarchy from outer to inner:
 
 - **Informatiestandaard**: top container (e.g. Medicatieproces 9). Owned by Nictiz.
 - **Use case**: a sub-chapter of an informatiestandaard, equal to a "scenario" in ART-DECOR. Coarse business framing.
-- **Transactiegroep**: a bundle of related transactions, e.g. `Medicatiegegevens (MGR/MGB)` for the pull variant or `Medicatievoorschrift (VOS/VOO)` for the push variant. The smallest unit that names a complete interaction.
-- **Transactie**: one direction of one exchange, e.g. `Raadplegen medicatiegegevens` or `Beschikbaarstellen medicatiegegevens`. FHIR or CDA profiles attach at this level.
+- **Transactiegroep**: a named group of related transacties, e.g. `Verstrekkingsverzoek (raadplegen/beschikbaarstellen)`, bundling the `Raadplegen verstrekkingsverzoek` and `Beschikbaarstellen verstrekkingsverzoek` transacties.
+- **Transactie**: a single interaction within a transactiegroep, e.g. `Raadplegen verstrekkingsverzoek` (consult or request from a source) or `Beschikbaarstellen verstrekkingsverzoek` (publish, for instance to an index). FHIR or CDA profiles attach at this level.
 - **Operation** (interactie-id on the wire): a single wire-level operation within a transactie, identified as `<verb>:<artifact>:<version>` (e.g. `search:zib-MedicationAgreement:2`). One transactie has one or more operations; an artifact is a Zib or a FHIR Bundle profile.
 - **Systeemrol**: the role a system plays in a transactie. Four kinds: Sturend, Ontvangend, Raadplegend, Beschikbaarstellend. Unit of qualification.
 - **Bedrijfsrol**: the role a person plays in a transactie (Voorschrijver, Verstrekker, ...). Cross-cutting actor type.
@@ -42,51 +42,53 @@ The **use case is the unit of authorization** in this proposal. A single user-fa
 
 #### Layer 2: Trust Framework
 
+Layer 2 is where the trust framework adds the constructs that gate access on top of the Nictiz catalogue. It is presented in two views: first the general mechanism that turns presented claims into an access decision, then the concrete actors and credentials that supply those claims in the Dutch context. In both diagrams, Nictiz catalogue entities are shown in yellow (referenced from layer 1, not redefined here), trust-framework policy and actors in pale blue, and identity claims and credentials in mid-blue.
+
+**Role resolution and permission.**
+
+{% include authorization-model-role-resolution.svg %}
+
+Authorization is decided in two decoupled steps. First, *role resolution*: a `RolePrerequisite` resolves the identity claims a requester presents to an `AuthorizationRole`, which is one Nictiz `Bedrijfsrol` refined by a set of claims (typically rolcodes). A role may have several RolePrerequisites and satisfying any one is enough, so a new credential route can be added without touching the permission rules; this also subsumes the presence check (the required claim types are exactly what the prerequisites read). Second, *permission*: the `PermissionMatrix` keys on the `AuthorizationRole` and the `Transactie` and yields allow or deny plus a `delegatable` flag. The AORTA realisation of the matrix is the *Autorisatierichtlijn medicatieveiligheid*, a table mapping (rolcode, transactie) to ja/nee.
+
+The system side mirrors the first step but needs no matrix: a `SysteemrolPrerequisite` resolves the product's claims (its qualification) directly to a `Systeemrol`. Because Nictiz defines a fine-grained systeemrol per transactie endpoint, being qualified for the systeemrol already is per-transactie permission; the matrix is only needed on the professional side, where the bedrijfsrol is coarse.
+
+**Actors and credentials.**
+
+Role resolution treats the claims abstractly. This view fills that in for the Dutch context: who the actors are, the credentials carrying the identity claims that role resolution consumes, and the context claims (such as the Enrollment) the actors produce for the context gate.
+
 {% include authorization-model-layer2.svg %}
 
-The Nictiz-layer entities `UseCase`, `Systeemrol`, and `Bedrijfsrol` appear in yellow because they are referenced from layer 1; they are not redefined here. Layer-2 entities are shown in blue.
-
-**Governance and policy:**
-
-- **TrustFramework**: an independently governed authorization regime (afsprakenstelsel). Owns the qualification programme, the identity-claim vocabulary, the authentication profiles, and the authorization policies used within its boundary.
-- **AuthenticationProfile** (the *presence* gate): defined per use case, lists the identity-claim *types* that must be present and valid on a request. Answers the question "is this request well-formed for the use case". For example, "any request for use case X must carry a rolcode claim, an organisation_id claim, a systeemrol claim, and an attest claim". Says nothing about which values of those claims are permitted. Shown in the diagram with `required_claim_types[]` as an attribute, rather than an explicit edge to `IdentityClaim`, to keep the diagram readable.
-- **AuthorizationPolicy** (the *permission* gate): defined per use case, specifies which combinations of identity-claim *values* are permitted for each operation in the use case. Answers the question "does this caller, with these specific claim values, have permission to perform this specific operation". For example, "rolcode `01.015` (Huisarts) is allowed to raadplegen MA, but not to beschikbaarstellen MA". Says nothing about which claim types must be present (that is the AuthenticationProfile's job). The AORTA realisation for medication is the *Autorisatierichtlijn medicatieveiligheid* published by VZVZ: a matrix mapping (rolcode, action, dataset) to ja/nee that the AS consults at mint time. Shown in the diagram with `allowed_combinations[]` as an attribute rather than explicit edges to `IdentityClaim` and `Operation`, for the same readability reason as `AuthenticationProfile`.
-
-The two are deliberately separated along the standard authentication-vs-authorization split. Presence and integrity is checked first via the AuthenticationProfile; permission given values is checked second via the AuthorizationPolicy. Mixing them into one entity is possible in implementation, but the conceptual gates remain distinct.
-
-**Actors:**
-
 - **HealthcareProfessional, HealthcareOrganization, ServiceProvider**: the three professional-side actor layers. The professional is employed by an organisation; the organisation is served by a service provider.
-- **Patient**: the data subject. In professional flows the patient is referenced via their BSN as the data-scope of the access token; the request principal is the ServiceProvider acting for the HealthcareProfessional and HealthcareOrganization. In *patient-channel (PHR) flows*, the patient becomes the asserting principal: they authenticate via DigiD with their PGO, and the PGO operator (a ServiceProvider qualified as a Dienstverlener Persoon under MedMij) makes the access-token request on their behalf. In both flows the `patient` attribute on the AccessTokenRequest carries the data-subject BSN; in PHR flows that BSN coincides with the authenticating principal's BSN.
+- **Patient**: the data subject. In professional flows the patient is referenced via their BSN as the data-scope of the access token; the request principal is the ServiceProvider acting for the HealthcareProfessional and HealthcareOrganization. In *patient-channel (PHR) flows* the patient becomes the asserting principal: they authenticate via DigiD with their PGO, and the PGO operator (a ServiceProvider qualified as a Dienstverlener Persoon under MedMij) makes the access-token request on their behalf. In both flows the `patient` attribute on the AccessTokenRequest carries the data-subject BSN; in PHR flows that BSN coincides with the authenticating principal's BSN.
+- **IdentityClaim** (abstract): a typed assertion about the requester. Generalises rolcode, organisation identifiers, the systeemrol or bedrijfsrol assertion, the Qualification and the two delegations. Each trust framework defines its own vocabulary.
+- **Qualification**: certifies that a vendor product (used by a service provider) may act in a given systeemrol. AORTA term: kwalificatie, recorded in TKID; MedMij splits it into DVA (provider-side) and DVP (PGO-side).
+- **HealthcareProfessional-to-HealthcareOrganization delegation**: the credential by which a professional delegates a set of bedrijfsrollen to their organisation. It is the *mandaattoken* behind the matrix's `delegatable` flag.
+- **ServiceProvider delegation**: the credential by which an organisation delegates a set of systeemrollen to its service provider.
+- **ContextClaim** (abstract) and **Enrollment**: assertions about the request and the patient, not the requester. `Enrollment` is the treatment relationship: the professional issues it to the organisation, attesting that they enrol or treat the patient. It feeds the use-case context gate, not role resolution.
 
-**Identity claims (asserted by the requester):**
-
-- **IdentityClaim** (abstract): a typed assertion about the requester that the policy evaluates. Generalises systeemrol, bedrijfsrol, rolcode, organisation identifiers, attest grounds, and similar. Each trust framework defines its own vocabulary. The Qualification and both delegations below are shown in the diagram as concrete subtypes of `IdentityClaim`.
-- **Qualification**: the certification that a vendor product (used by a service provider) may act in a given systeemrol. Issued by the trust framework. AORTA term: kwalificatie, recorded in TKID. MedMij splits this into DVA (provider-side) and DVP (PGO-side). Upstream of OAuth; the AS treats it as a precondition.
-- **HealthcareProfessional-to-HealthcareOrganization delegation**: the credential by which a healthcare professional grants their healthcare organisation authority to act on their professional responsibility, scoped to a set of bedrijfsrollen. The professional can only delegate what they ARE (a Voorschrijver, a Verstrekker, ...), so the delegation is at bedrijfsrol granularity.
-- **ServiceProvider delegation**: the credential by which a healthcare organisation grants a service provider authority to act for it on the wire, scoped to a set of systeemrollen. The healthcare organisation delegates technical capability.
-
-The delegation chain runs at two different layers: the HealthcareProfessional-to-HealthcareOrganization delegation operates at bedrijfsrol level, and the ServiceProvider delegation operates at systeemrol level. Each step delegates at the layer it can actually express. A healthcare professional is not a system; they cannot delegate a systeemrol.
+The delegation chain runs at two layers: the professional-to-organisation delegation at bedrijfsrol level, the service-provider delegation at systeemrol level. Each step delegates only what it can express; a professional is not a system, so cannot delegate a systeemrol. The identity claims feed role resolution and the matrix above; the context claims, such as the Enrollment, feed the use-case context gate.
 
 #### Layer 3: OAuth wire artefacts
 
 {% include authorization-model-layer3.svg %}
 
-Layer 1 entities (`UseCase`, `Operation`, `FHIRResource`) appear in yellow; layer 2 entities (`IdentityClaim`, `ServiceProvider`) appear in blue. Layer-3 entities are shown in green.
+Layer 1 entities (`Transactie`, `Operation`, `FHIRResource`) appear in yellow; layer 2 entities (`IdentityClaim`, `ServiceProvider`) appear in blue. Layer-3 entities are shown in green.
 
-- **AccessTokenRequest**: what the ServiceProvider sends to the AS. Carries one use-case scope token (the `uc`), the list of requested operations (interactie-ids), the asserted identity claims, and the patient context.
-- **AccessToken**: the OAuth 2.0 artefact returned on success. Authorizes exactly one use case, carries the verified identity claims, and carries the minted SMART on FHIR scopes.
+- **AccessTokenRequest**: what the ServiceProvider sends to the AS. Carries one transactie scope token (the `tx`), an optional list of operations (interactie-ids) that narrow the minted scopes, the asserted identity claims, and the context claims.
+- **AccessToken**: the OAuth 2.0 artefact returned on success. Authorizes exactly one transactie, carries the verified identity claims, and carries the minted SMART on FHIR scopes.
 - **SoFScope**: a [SMART on FHIR v2](https://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html) scope (`<context>/<Resource>.<crud>`). The unit of resource-server enforcement, minted at issue time from the requested operations via the Zib and FHIRResource chain.
 
-Note the asymmetry between request and response: the **request carries interactie-ids**, the **response carries SMART on FHIR scopes**. The AS converts the former into the latter at mint time.
+Note the asymmetry between request and response: the **request carries the transactie token** (optionally narrowed by interactie-ids), the **response carries the transactie token plus the minted SMART on FHIR scopes**. The AS converts requested operations into scopes at mint time.
 
-An AT scoped to a use case can cover multiple transactiegroepen, each potentially using a different systeemrol. The AS verifies, per requested operation, that the matching systeemrol is qualified and delegated.
+An AT is scoped to one transactie, which uses one systeemrol; the AS verifies that systeemrol is qualified and delegated. Operations in the request only narrow the minted scopes.
 
-#### Why use case is the scope unit
+#### Why the transactie is the scope unit
 
-- A *transactie* is too fine: a single direction (raadplegen without beschikbaarstellen) is meaningless on its own.
-- A *transactiegroep* is conceptually coherent but operationally inconvenient. Most real data requests span multiple transactiegroepen within one use case. Forcing one AT per transactiegroep multiplies round-trips and complicates correlation.
-- A *use case* matches how Nictiz organises related transacties and how data consumers think about a data request. Per-direction enforcement (systeemrol, bedrijfsrol, attest) still happens via the asserted identity claims and the operation-membership check at mint time.
+- The *transactie* is the grain at which the PermissionMatrix decides: each cell maps `(AuthorizationRole, Transactie)` to allow or deny. Scoping the AT to one transactie aligns the wire with the decision, the AS reads the transactie, resolves the role, and looks up one cell.
+- The prerequisites are per transactie: which conditions must hold (the role resolution, the systeemrol qualification, the delegation, the context check) are set by the transactie. Bundling several transacties into one AT would mean satisfying the union of their prerequisites, which is awkward to express and can even conflict.
+- A *use case* is therefore too coarse for the AT scope: one AT would span many transacties with differing prerequisites, and an operation shared between them could not be attributed to a single cell. The use case is only a catalogue grouping of transacties, not a key the matrix or the AT needs, and it does not appear on the wire.
+- An *operation* is too fine: it is a wire-level interactie-id used for least-privilege scope minting, below the grain at which permission is decided.
+- An AT covers one activity the requester performs (one transactie, e.g. `raadplegen verstrekkingsverzoek`). A request that needs several transacties at once (a full medication overview for one patient) is served by an overview transactie such as Medicatieoverzicht, itself one transactie, or by issuing several ATs.
 
 ### Problem
 
@@ -115,7 +117,7 @@ Concrete consequences:
 
 ### Specification
 
-The Problem section above sets out what the convention has to address. The subsections below state the normative rules. Cumulatively, they require a shared layer-2 model, a uniform use-case identifier format on the OAuth wire, a single use case per request with the identifier preserved on the issued AT, and policy lookup by direct identifier match rather than derivation. The model is independent of how identity claims are attested.
+The Problem section above sets out what the convention has to address. The subsections below state the normative rules. Cumulatively, they require a shared layer-2 model, a uniform transactie identifier format on the OAuth wire, a single transactie per request with the identifier preserved on the issued AT, and policy lookup by direct identifier match rather than derivation. The model is independent of how identity claims are attested.
 
 #### Authorization information model
 
@@ -124,41 +126,44 @@ The normative model for layers 2 and 3 is the one shown in the Layer 2 and Layer
 - A ServiceProvider's Qualifications SHALL be expressed per systeemrol.
 - A HealthcareProfessional-to-HealthcareOrganization delegation SHALL be expressed per bedrijfsrol.
 - A ServiceProvider delegation SHALL be expressed per systeemrol.
-- An AuthenticationProfile SHALL be defined per use case and SHALL enumerate the identity-claim types required for that use case.
-- An AccessTokenRequest SHALL reference exactly one UseCase and zero-or-more Operations.
-- An AccessToken SHALL authorize exactly one UseCase.
+- A RolePrerequisite SHALL resolve presented identity claims to an AuthorizationRole, which refines exactly one Bedrijfsrol; a role MAY have several RolePrerequisites, and satisfying any one is sufficient.
+- A SysteemrolPrerequisite SHALL resolve a ServiceProvider's claims to a Systeemrol.
+- The PermissionMatrix SHALL map (AuthorizationRole, Transactie) to allow or deny plus a delegatable flag.
+- An AccessTokenRequest SHALL be scoped to exactly one Transactie and MAY narrow to a subset of that transactie's operations.
+- An AccessToken SHALL authorize exactly one Transactie.
 
 Trust frameworks MAY use additional concepts beyond these (framework-specific governance entities, for example), but SHALL NOT redefine the meaning of the concepts above.
 
-#### Use-case scope token
+#### Transactie scope token
 
-Every AT request defines exactly one use-case scope token with the format:
+Every AT request defines exactly one transactie scope token with the format:
 
 ```
-<governance-body>.uc.<information-standard>.<use-case>.<version>
+<governance-body>.tx.<information-standard>.<transactie>.<version>
 ```
 
 Examples:
 
 ```
-aorta.uc.mp.medicatiegegevens.3-0-0
-aorta.uc.mp.medicatievoorschrift.3-0-0
-aorta.uc.bgz.bgz.1-0
-medmij.uc.medicatie.actueel.1-0
-nuts.uc.eoverdracht.notifying.1-0
+aorta.tx.mp.verstrekkingsverzoek-raadplegen.3-0-0
+aorta.tx.mp.medicatieafspraak-beschikbaarstellen.3-0-0
+aorta.tx.mp.medicatieoverzicht-raadplegen.3-0-0
+medmij.tx.medicatie.medicatieafspraak-raadplegen.1-0
 ```
 
 Segment rules:
 
 - `<governance-body>`: the body governing the namespace (`aorta`, `medmij`, `twiin`, `nuts`, ...).
-- `uc`: literal marker, identifying the token as a use-case scope token.
+- `tx`: literal marker, identifying the token as a transactie scope token.
 - `<information-standard>`: the informatiestandaard slug within the governance body (`mp` for Medicatieproces, `bgz`, `eoverdracht`, ...).
-- `<use-case>`: kebab-case use-case identifier within the information standard.
+- `<transactie>`: kebab-case transactie identifier (e.g. `verstrekkingsverzoek-raadplegen`).
 - `<version>`: hyphen-separated semantic version (`3-0-0`), or a single integer for major-only versioning (`3`). No `v` prefix, to match the operation token format below.
+
+The use case the transactie belongs to is derivable from the catalogue and is not carried on the wire.
 
 #### Operation token format
 
-Operations are the fine-grained interactie-ids that appear in the request scope alongside the use-case token. The format is defined by the [AORTA-on-FHIR interactietabel](https://aorta-on-fhir.public.vzvz.nl/aorta-on-fhir-specificaties/Working-version/aorta-interactietabel). Two shapes exist:
+Operations are the fine-grained interactie-ids that MAY appear in the request scope alongside the transactie token, to narrow the scopes minted from it for least-privilege; each must belong to the scoped transactie, and omitting them requests all of the transactie's operations. The format is defined by the [AORTA-on-FHIR interactietabel](https://aorta-on-fhir.public.vzvz.nl/aorta-on-fhir-specificaties/Working-version/aorta-interactietabel). Two shapes exist:
 
 ```
 <verb>:<artifact>:<version>                       AORTA-internal style
@@ -190,7 +195,7 @@ Segment rules:
 - `<version>` is the version of the interactie definition itself, not of the zib or FHIR resource. Bare integer for AORTA-internal style (`1`, `2`); dotted decimal for MedMij-facing style (`1.0`). This matches the version format of the use-case token (numeric, no `v` prefix).
 - `<request|response>` (MedMij style only) marks the direction of the message in a paired exchange.
 
-Each operation in a request scope must belong to a transactiegroep within the scoped use case. The AS verifies this at mint time.
+Each operation in a request scope must belong to the scoped transactie. The AS verifies this at mint time.
 
 The exact shape of the operation token is information-standard-specific: each informatiestandaard registers its own artifact prefixes and version conventions. New information standards are encouraged to follow the `<verb>:<artifact>:<version>` shape above for cross-framework consistency, but the proposal does not mandate it.
 
@@ -202,54 +207,49 @@ The two formats are deliberately distinguishable at a glance (the use-case token
 
 #### Conformance: AT request
 
-> **REQ-1 (SHALL).** An AT request SHALL contain exactly one use-case scope token.
+> **REQ-1 (SHALL).** An AT request SHALL contain exactly one transactie scope token.
 >
 > **REQ-2 (SHALL).** The AS SHALL reject the request if REQ-1 is violated (zero or more than one token).
 >
-> **REQ-3 (MAY).** The request scope MAY contain additional scope tokens (fine-grained operation requests as interactie-ids, channel tags), to be evaluated against the use case's allowed set.
+> **REQ-3 (MAY).** The request scope MAY contain operation tokens (interactie-ids), each one belonging to the scoped transactie, to narrow the minted scopes for least-privilege.
 >
-> **REQ-4 (SHOULD).** Clients SHOULD include only the operation tokens they actually intend to use (least-privilege).
+> **REQ-4 (SHALL).** The AS SHALL reject any operation token that does not belong to the scoped transactie.
 
 #### Conformance: issued AT
 
-> **REQ-5 (SHALL).** The issued AT SHALL carry the use-case identifier as a `uc` claim, whose value equals the request's use-case scope token.
+> **REQ-5 (SHALL).** The issued AT SHALL carry the transactie identifier as a `tx` claim, whose value equals the request's transactie scope token.
 >
-> **REQ-6 (SHALL).** The use-case scope token SHALL also appear in the AT's `scope` claim alongside the minted SMART on FHIR scopes.
+> **REQ-6 (SHALL).** The transactie scope token SHALL also appear in the AT's `scope` claim alongside the minted SMART on FHIR scopes.
 
 #### Conformance: AS behaviour
 
-> **REQ-7 (SHALL).** The AS SHALL select the applicable policy by direct lookup of the use-case identifier, not by derivation from other tokens or context.
+> **REQ-7 (SHALL).** The AS SHALL select the applicable PermissionMatrix entry by direct match of the transactie and the resolved AuthorizationRole, not by derivation from other tokens or context.
 >
-> **REQ-8 (SHALL).** For every requested operation, the AS SHALL verify that:
+> **REQ-8 (SHALL).** For the scoped transactie, the AS SHALL verify that:
 >
-> - the operation belongs to a transactiegroep within the scoped use case;
-> - the matching systeemrol is qualified for the ServiceProvider and authorized by the ServiceProvider delegation;
-> - the corresponding bedrijfsrol is authorized by the HealthcareProfessional-to-HealthcareOrganization delegation issued by the asserting healthcare professional;
-> - the asserted rolcode is permitted to perform the operation per the use case's AuthorizationPolicy.
+> - the transactie's systeemrol is qualified for the ServiceProvider (via a SysteemrolPrerequisite) and authorized by the ServiceProvider delegation;
+> - the presented identity claims resolve, via a RolePrerequisite, to an AuthorizationRole that the PermissionMatrix permits for the transactie;
+> - the HealthcareProfessional-to-HealthcareOrganization delegation authorizes the Bedrijfsrol that the AuthorizationRole refines;
+> - the context gate passes (Mitz consent, treatment relationship, purpose-of-use, where required).
 >
-> **REQ-9 (SHALL).** The AS SHALL reject requests whose use-case identifier maps to no known policy.
+> **REQ-9 (SHALL).** The AS SHALL reject the request if the transactie is unknown, no PermissionMatrix entry permits the resolved AuthorizationRole, or any check in REQ-8 fails.
 
-#### Identity claims and verification
+#### Identity claims, context, and verification
 
-Identity claims are the typed assertions the AS evaluates. The set asserted on a single request typically includes:
+Identity claims are the typed assertions the AS resolves into roles. For the scoped transactie the set typically includes:
 
-- The professional's identifier (UZI) and rolcode.
+- The professional's identifier (UZI) and rolcode (the DEZI-role).
 - The organisation's identifier (URA) and role type.
-- The systeemrol (or systeemrollen, if the request spans multiple transactiegroepen).
-- The bedrijfsrol (or bedrijfsrollen) the asserting professional is acting under.
-- The relevant attest grounds (treatment relationship, consent, ...).
-- The ServiceProvider's Qualification.
-- The two delegation credentials in the chain.
+- The systeemrol the transactie uses.
+- The ServiceProvider's Qualification and the two delegation credentials in the chain.
 
 In current Dutch implementations these claims appear in several forms, sometimes mixed within one request: signed claims in SAML tokens, Verifiable Credentials, JWT claims issued by a trusted Authorization Server, or claims derived from an mTLS client certificate. The proposal works with any of these; it does not prescribe a wire format.
 
-The use case's AuthenticationProfile lists which identity-claim types must be present. The AS checks the asserted claims against that list at request time. The further per-operation verifications (systeemrol, qualification, delegations, rolcode permission) are specified in REQ-8 under the AS behaviour conformance subsection.
+There is no separate presence profile. The claims a request must carry are exactly those the transactie's RolePrerequisite and SysteemrolPrerequisite read to resolve the AuthorizationRole and the Systeemrol. Adding a credential route means adding a prerequisite, not editing a list.
 
-**Multi-systeemrol and multi-bedrijfsrol requests.** A single AT request can cover multiple transactiegroepen within the use case, each potentially requiring a different systeemrol or bedrijfsrol. The convention is that the client presents all relevant role claims up front, and the AS resolves the appropriate role per operation. Concretely:
+**Context gate.** Role resolution answers "who is the requester"; the context gate answers "is sharing this patient's data allowed". It evaluates ContextClaims about the request rather than the requester, typically the patient (BSN), the Enrollment (the patient's treatment relationship, issued by the professional to the organisation), Mitz consent, and purpose-of-use. The gate belongs to the use case, which carries the intent; because a transactie belongs to exactly one use case, the scoped transactie fixes which context gate applies. The AS evaluates it alongside the PermissionMatrix (REQ-8).
 
-> **REQ-10 (SHALL).** The client SHALL present, as asserted identity claims on the request, all systeemrollen and all bedrijfsrollen that may apply to any of the requested operations within the use case. The AS SHALL resolve, per operation, which asserted systeemrol matches the operation's initiating systeemrol and which asserted bedrijfsrol applies; it SHALL verify each independently against the relevant Qualification, ServiceProvider delegation, and HealthcareProfessional-to-HealthcareOrganization delegation.
-
-A delegation at one systeemrol does not imply any other systeemrol; the same holds for bedrijfsrollen. The AS reasons over the asserted set as a whole, but each per-operation check is independent.
+> **REQ-10 (SHALL).** The client SHALL present the identity claims needed to resolve the AuthorizationRole and the Systeemrol for the scoped transactie, together with the ContextClaims the use case's context gate requires. The AS SHALL verify role resolution, the matrix permission, and the context gate independently, and SHALL reject the request if any required claim is absent or any check fails.
 
 ### Evaluation flow
 
@@ -257,74 +257,61 @@ A delegation at one systeemrol does not imply any other systeemrol; the same hol
 
 Happy path. Any check failure results in rejection, not shown for clarity. The legend on the diagram marks each step's input sources: **R** for the AT request, **L1** for the Nictiz catalogue (layer 1), **L2** for the trust framework registry (layer 2). Steps that depend on derived context (e.g. "the required systeemrol per operation") inherit their source from the step that resolved that context.
 
-When the AT request spans multiple transactiegroepen within the use case, the qualification and the two delegation checks happen per operation: each operation may require a different systeemrol or bedrijfsrol.
+Because the AT is scoped to a single transactie, role resolution, the systeemrol qualification and delegation check, the matrix lookup, and the context gate are each evaluated once for that transactie; any operations in the request only narrow the minted scopes.
 
 ### Examples
 
 *This section is non-normative.* Each example shows the request scope, the AS decision summary, and the token introspection response ([RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662)) that the resource server or audit subsystem would receive for the issued AT. The introspection responses are illustrative and do not specify a wire format; specific identifier values are placeholders. Trust-anchored identity claims are shown abstractly; how they are proven is out of scope.
 
-#### MedMij: PGO fetches medication data
+#### Worked example: a GP consults a patient's medication agreements
 
-Request scope:
-
-```
-medmij.uc.medicatie.actueel.1-0
-search:MedicationRequest:1.0:request
-search:MedicationStatement:1.0:request
-```
-
-Asserted identity claims: `subject_id` (citizen via DigiD).
-
-AS decision: the use case exists, both operations belong to transactiegroepen within it, the asserted claims satisfy the policy.
-
-Token introspection response:
-
-```json
-{
-  "active": true,
-  "uc": "medmij.uc.medicatie.actueel.1-0",
-  "scope": "medmij.uc.medicatie.actueel.1-0 patient/MedicationRequest.s patient/MedicationStatement.s",
-  "client_id": "...pgo-app...",
-  "sub": "bsn:999999990",
-  "patient": "bsn:999999990",
-  "token_type": "Bearer",
-  "exp": 1760000000,
-  "iat": 1759999100
-}
-```
-
-#### AORTA professional pull: GP queries medication overview
-
-A GP queries the medication overview of a specific patient. The request spans operations from multiple transactiegroepen within the `medicatiegegevens` use case.
-
-Request scope:
+**Use case** Medicatiebouwstenen, **transactie** Raadplegen medicatieafspraak. The request scope is one transactie token plus, optionally, the operations that narrow the minted scopes:
 
 ```
-aorta.uc.mp.medicatiegegevens.3-0-0
+aorta.tx.mp.medicatieafspraak-raadplegen.3-0-0
 search:mp-MedicationAgreement:1
-search:mp-MedicationDispense:1
-search:mp-AdministrationAgreement:1
-search:mp-MedicationUse2:1
 ```
 
-Asserted identity claims:
+**Layer-2 registry for this transactie**
 
-- `subject_id` (behandelaar UZI)
-- `rolcode=Huisarts`
-- `organisation_id` (URA)
-- `organisation_role=Huisarts`
-- `systeemrol=MedicatieGegevensRaadplegend`
-- `bedrijfsrol=Medicatieraadpleger`
+*System side, `SysteemrolPrerequisite`.* The transactie's systeemrol is `MedicatieafspraakRaadplegend`. It is filled only when the request carries **both** a Qualification and a ServiceProvider delegation that name that systeemrol:
 
-AS decision: the use case exists; for each requested operation, the asserted `MedicatieGegevensRaadplegend` is the initiating systeemrol of the matching transactie; the ServiceProvider's Qualification covers that systeemrol; the ServiceProvider delegation authorizes it; the HealthcareProfessional-to-HealthcareOrganization delegation issued by the GP to their organisation authorizes the required `Medicatieraadpleger` bedrijfsrol.
+| resolves Systeemrol | requires Qualification (value) | and ServiceProvider delegation (value) |
+|---|---|---|
+| `MedicatieafspraakRaadplegend` | `systeemrol = MedicatieafspraakRaadplegend` | `systeemrol = MedicatieafspraakRaadplegend` |
+{:.grid .table-hover}
 
-Token introspection response:
+*Professional side, `RolePrerequisite`.* An `AuthorizationRole` is a `Bedrijfsrol` refined by a rolcode set, and the name carries the discriminator (e.g. `MedicatieRaadplegerArts`). Each row below is one filling: the claims that must be present to resolve that role. All three refine the same bedrijfsrol `Medicatieraadpleger`, differing only in the rolcode set:
+
+| resolves AuthorizationRole | requires rolcode in | and HCP-to-HCO delegation (value) |
+|---|---|---|
+| `MedicatieRaadplegerArts` | `{ 01.015 Huisarts, ... (artsen, MS'en, VS'en, PA's per richtlijn) }` | `bedrijfsrol = Medicatieraadpleger` |
+| `MedicatieRaadplegerApotheker` | `{ 17.000 Apotheker, 17.060 Ziekenhuisapotheker, 17.075 Openbaar apotheker }` | `bedrijfsrol = Medicatieraadpleger` |
+| `MedicatieRaadplegerVerpleegkundige` | `{ 30.000 Verpleegkundige }` | `bedrijfsrol = Medicatieraadpleger` |
+{:.grid .table-hover}
+
+*`PermissionMatrix`* (slice for this transactie), keyed on `(AuthorizationRole, Transactie)`:
+
+| AuthorizationRole | Raadplegen medicatieafspraak | delegatable (mandaattoken) |
+|---|---|---|
+| `MedicatieRaadplegerArts` | allow | ja |
+| `MedicatieRaadplegerApotheker` | allow | ja |
+| `MedicatieRaadplegerVerpleegkundige` | deny | - |
+{:.grid .table-hover}
+
+The rolcode discriminator is what lets the matrix differ per rolcode set even within one bedrijfsrol: here a verpleegkundige is denied, and for the sibling transactie `beschikbaarstellen medicatieafspraak` the Autorisatierichtlijn permits artsen but not apothekers.
+
+*Context gate (on the use case).* Medicatiebouwstenen requires, for this patient, an Enrollment (treatment relationship) and a Mitz consent that permits sharing medication data. ContextClaims: `patient` (BSN), `Enrollment`, `mitzConsent`.
+
+**AS decision.** A huisarts requests it. Role resolution: `rolcode=01.015` is in the `MedicatieRaadplegerArts` set and the HCP-to-HCO delegation names `Medicatieraadpleger`, so the role resolves to `MedicatieRaadplegerArts`. System side: the Qualification and the ServiceProvider delegation both name `MedicatieafspraakRaadplegend`, so the systeemrol resolves. Matrix: `(MedicatieRaadplegerArts, Raadplegen medicatieafspraak)` = allow, delegatable. Context gate: treatment relationship and Mitz consent pass. The AT is issued.
+
+**Issued AT (introspection).** The operation mints the SMART scope (`mp-MedicationAgreement` maps to FHIR `MedicationRequest`):
 
 ```json
 {
   "active": true,
-  "uc": "aorta.uc.mp.medicatiegegevens.3-0-0",
-  "scope": "aorta.uc.mp.medicatiegegevens.3-0-0 patient/MedicationRequest.s patient/MedicationDispense.s patient/MedicationStatement.s",
+  "tx": "aorta.tx.mp.medicatieafspraak-raadplegen.3-0-0",
+  "scope": "aorta.tx.mp.medicatieafspraak-raadplegen.3-0-0 patient/MedicationRequest.rs",
   "client_id": "...gp-ehr...",
   "sub": "uzi:00000123",
   "patient": "bsn:999999990",
@@ -334,33 +321,41 @@ Token introspection response:
 }
 ```
 
-#### AORTA professional push: voorschrijver sends prescription
+#### Same dataset, different use case: a citizen via MedMij
 
-Request scope:
+The same medicatieafspraak fetched through a citizen's PGO is a **different transactie**, because the use case and its context gate differ: the citizen authenticates with DigiD, the role resolves to the patient rather than a professional, and there is no treatment-relationship gate. Only the operation (`search:...MedicationAgreement...`) is shared.
 
 ```
-aorta.uc.mp.medicatievoorschrift.3-0-0
+medmij.tx.mp.medicatieafspraak-raadplegen.1-0
+```
+```json
+{
+  "active": true,
+  "tx": "medmij.tx.mp.medicatieafspraak-raadplegen.1-0",
+  "scope": "medmij.tx.mp.medicatieafspraak-raadplegen.1-0 patient/MedicationRequest.rs",
+  "client_id": "...pgo-app...",
+  "sub": "bsn:999999990",
+  "patient": "bsn:999999990",
+  "token_type": "Bearer",
+  "exp": 1760000000,
+  "iat": 1759999100
+}
+```
+
+#### A write transactie: a voorschrijver sends a prescription
+
+```
+aorta.tx.mp.medicatievoorschrift-sturen.3-0-0
 transaction:mp-MedicationPrescriptionProcessing-Bundle:1
 ```
 
-Asserted identity claims:
-
-- `subject_id` (behandelaar UZI)
-- `rolcode=Huisarts`
-- `organisation_id` (URA)
-- `organisation_role=Huisarts`
-- `systeemrol=VoorschriftSturend`
-- `bedrijfsrol=Voorschrijver`
-
-AS decision: the use case exists; the bundle operation belongs to the `medicatievoorschrift` use case via its transactiegroep; the asserted `VoorschriftSturend` is the initiating systeemrol; the ServiceProvider is qualified and delegated for that systeemrol; the HealthcareProfessional-to-HealthcareOrganization delegation authorizes the `Voorschrijver` bedrijfsrol.
-
-Token introspection response:
+Role resolution resolves `AuthorizationRole = VoorschrijverArts` (`rolcode=01.015` plus the HCP-to-HCO delegation for bedrijfsrol `Voorschrijver`); the systeemrol is `VoorschriftSturend` (Qualification and ServiceProvider delegation both naming it); the matrix permits `(VoorschrijverArts, Sturen medicatievoorschrift)`; the bundle operation mints write scopes.
 
 ```json
 {
   "active": true,
-  "uc": "aorta.uc.mp.medicatievoorschrift.3-0-0",
-  "scope": "aorta.uc.mp.medicatievoorschrift.3-0-0 patient/MedicationRequest.cu patient/MedicationRequest.s",
+  "tx": "aorta.tx.mp.medicatievoorschrift-sturen.3-0-0",
+  "scope": "aorta.tx.mp.medicatievoorschrift-sturen.3-0-0 patient/MedicationRequest.cu",
   "client_id": "...gp-ehr...",
   "sub": "uzi:00000123",
   "patient": "bsn:999999990",
@@ -374,19 +369,23 @@ Token introspection response:
 
 - **AS**: Authorization Server, mints access tokens.
 - **AT**: Access Token.
-- **AccessTokenRequest**: the OAuth 2.0 request sent by the ServiceProvider to the AS, carrying the `uc` scope token, requested operations, asserted identity claims, and patient context.
-- **AuthenticationProfile**: a layer 2 entity defined per use case that enumerates the identity-claim types the use case requires. Checked at request time against the asserted claims.
-- **AuthorizationPolicy**: a layer 2 entity defined per use case that lists which combinations of identity-claim values (typically rolcode) are permitted for which operations. The AORTA realisation for medication is the *Autorisatierichtlijn medicatieveiligheid*.
-- **Bedrijfsrol**: the role a person plays in a transactie (Voorschrijver, Verstrekker, Toediener, ...). Unit of HealthcareProfessional-to-HealthcareOrganization delegation in this proposal.
+- **AccessTokenRequest**: the OAuth 2.0 request sent by the ServiceProvider to the AS, carrying the `tx` scope token, optional operations, asserted identity claims, and context claims.
+- **AuthorizationRole**: the subject the PermissionMatrix keys on; one Nictiz Bedrijfsrol refined by a set of identity claims (typically rolcodes), resolved from presented claims by a RolePrerequisite.
+- **Bedrijfsrol**: the role a person plays in a transactie (Voorschrijver, Verstrekker, Toediener, ...). Unit of HealthcareProfessional-to-HealthcareOrganization delegation, and the role an AuthorizationRole refines.
 - **IdentityClaim**: a typed assertion about the requester that the policy evaluates. Carried in many wire formats (signed SAML claim, Verifiable Credential, JWT claim by a trusted AS, mTLS-derived claim, ...).
+- **ContextClaim**: a typed assertion about the request context rather than the requester (patient, Enrollment, Mitz consent, purpose-of-use), evaluated by the use case's context gate.
+- **Enrollment**: a ContextClaim for the patient's treatment relationship; the professional issues it to the organisation, attesting that they enrol or treat the patient.
 - **Informatiestandaard**: a Nictiz healthcare information standard (e.g. Medicatieproces, BgZ).
 - **Kwalificatie**: qualification, the upstream certification that a vendor product may act as a given systeemrol.
 - **PDP**: Policy Decision Point, see [Authorization](authorization.html).
+- **PermissionMatrix**: a layer 2 entity, per use case, mapping (AuthorizationRole, Transactie) to allow or deny plus a delegatable flag. The AORTA realisation for medication is the *Autorisatierichtlijn medicatieveiligheid*.
+- **RolePrerequisite**: a layer 2 rule that resolves a set of identity claims to an AuthorizationRole; a role may have several, and satisfying any one is enough.
 - **RS**: Resource Server, enforces SMART on FHIR scopes on FHIR endpoints.
 - **SoF scope**: SMART on FHIR v2 scope, e.g. `patient/MedicationRequest.s`.
 - **Systeemrol**: the role a system plays in a transactie (Sturend, Ontvangend, Raadplegend, Beschikbaarstellend). Unit of qualification and of ServiceProvider delegation.
-- **Transactie**: one direction of one exchange within a transactiegroep.
-- **Transactiegroep**: a bundle of related transactions that together form a complete interaction. Unit of conformity but not surfaced on the OAuth wire by this proposal.
+- **SysteemrolPrerequisite**: a layer 2 rule that resolves a ServiceProvider's claims (notably its qualification) to a Systeemrol; the system-side analogue of a RolePrerequisite, with no matrix.
+- **Transactie**: a single interaction within a transactiegroep, e.g. `Raadplegen verstrekkingsverzoek` (consult) or `Beschikbaarstellen verstrekkingsverzoek` (publish). The unit the PermissionMatrix authorizes against.
+- **Transactiegroep**: a named group of related transacties, e.g. `Verstrekkingsverzoek (raadplegen/beschikbaarstellen)`.
 - **Trust framework**: an independently governed authorization regime (afsprakenstelsel).
 - **Use case**: a sub-chapter of an informatiestandaard, equal to a "scenario" in ART-DECOR. The unit of authorization in this proposal.
 - **Zib**: *zorginformatiebouwsteen*, a Dutch healthcare data model construct.

--- a/input/pagecontent/authorization-model.md
+++ b/input/pagecontent/authorization-model.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 ### Introduction
 
-Dutch healthcare data exchange runs under several trust frameworks (AORTA-on-FHIR, MedMij, Twiin, Nuts use-case communities). Each one has, over time, built its own authorization model. Each model is well documented within its own framework. But it is framework-local: it lives spread over registry definitions, policy documents, and wire conventions, in a vocabulary that only works inside that framework. No shared national model exists. The models overlap conceptually: qualifications, delegations, roles, and context checks appear in all of them. Yet they never align, and there is no shared vocabulary to compare them in.
+Dutch healthcare data exchange runs under several trust frameworks (AORTA-on-FHIR, MedMij, Twiin, Nuts use-case communities). Each one has, over time, built its own authorization model. Each model is well documented within its own framework. But it is framework-local: it lives spread over registry definitions, policy documents, and wire conventions, in a vocabulary that only works inside that framework. The models overlap conceptually: qualifications, delegations, roles, and context checks appear in all of them. Yet they never align: no shared vocabulary exists to compare them in.
 
 This proposal makes the model explicit. Its goal is twofold. First, it defines a shared _authorization information model_ in which each trust framework can express its own policies, layered on top of the Nictiz information-standard catalogue as the common basis. Second, it derives from that model one OAuth 2.0 convention for requesting access tokens, so that the frameworks share a wire format where they interoperate.
 
@@ -35,7 +35,7 @@ The Examples section shows every construct introduced below as a filled-in table
 
 This proposal models authorization in three layers. The layering is a modelling decision, not a given: it is chosen because the layers have different owners, change at different rates, and answer different questions. A layer groups concerns, not authors; one governance body can author artefacts in more than one layer.
 
-- **Layer 1, Information Standards** (the _information layer_) defines _what_ transactions exist and _what data_ they carry. In the Netherlands most information standards are maintained by Nictiz; this proposal adopts the Nictiz meta-model, per the [Handleiding Wiki documentatie](https://informatiestandaarden.nictiz.nl/wiki/Handleiding_Wiki_documentatie), as the layer-1 vocabulary. It catalogues information standards, use cases, transaction groups, transactions, system roles, business roles, and the datasets they operate on. The data definitions (datasets, zibs) are part of this layer; there is no separate data layer. The same for all trust frameworks.
+- **Layer 1, Information Standards** (the _information layer_) defines _what_ transactions exist and _what data_ they carry. In the Netherlands most information standards are maintained by Nictiz; this proposal adopts the Nictiz meta-model, per the [Handleiding Wiki documentatie](https://informatiestandaarden.nictiz.nl/wiki/Handleiding_Wiki_documentatie), as the layer-1 vocabulary. It catalogues information standards, use cases, transaction groups, transactions, system roles, business roles, and the datasets they operate on. The data definitions (datasets, zibs) are part of this layer; there is no separate data layer. This layer is the same for all trust frameworks.
 - **Layer 2, Trust Framework** (the _trust layer_) specifies _who_ may perform _which_ transactions, and under what conditions: role resolution, the permission matrix, qualifications, the delegation chain, identity claims, context claims. Today these constructs are filled per framework (VZVZ, MedMij, Twiin, Nuts-toepassingen). The model does not tie them to per-framework governance: with a shared vocabulary, layer-2 policies can be lifted to national governance where that is wanted.
 - **Layer 3, Realisation** (the _realisation layer_) specifies _how_ a transaction reaches the wire: the FHIR profiles that represent its data, the wire-level operations that carry it, and how a single authorization decision surfaces in an OAuth 2.0 exchange. The wire artefacts are the access-token request, the issued access token, and the granted scopes that the resource server enforces. This proposal realises the granted scopes as SMART on FHIR v2 scopes; the model does not depend on that choice.
 
@@ -61,7 +61,7 @@ Three structural points matter for authorization:
 - **There is no operation concept in layer 1.** The functional model stops at the transaction. The fine-grained wire-level operations are realisation constructs and are introduced in layer 3.
 - **Lifecycle rules are layer-1 facts.** Where an information standard defines a lifecycle for its data (status values and the permitted transitions), that state machine belongs to this layer. It surfaces in authorization as state rules on layer-3 operations, enforced by the resource server at request time; layer 3 works out why such rules never ride the access token.
 
-The transaction dataset itself shows which constructs belong in layer 2; the design notes contain that derivation.
+The transaction dataset itself shows what belongs in layer 2; the design notes contain that derivation.
 
 #### Layer 2: Trust Framework
 
@@ -73,16 +73,17 @@ This view shows who the actors are, the credentials carrying the identity claims
 
 {% include authorization-model-layer2.svg %}
 
-- **HealthcareProfessional, HealthcareOrganization, ServiceProvider**: the three actor layers of the professional channel. The professional is employed by an organisation; the organisation is served by a service provider. The model names healthcare organisations because the trust frameworks do; organisations outside care are out of scope here, though the mechanism does not preclude them.
+- **HealthcareProfessional, HealthcareOrganization, ServiceProvider**: the three actors of the professional channel. The professional is employed by an organisation; the organisation is served by a service provider. The model names healthcare organisations because the trust frameworks do; organisations outside care are out of scope here, though the mechanism does not preclude them.
 - **Patient**: the data subject, referenced via their BSN in the `patient` attribute of the AccessTokenRequest. In the professional channel the request principal is the ServiceProvider acting for the professional and the organisation; in the patient channel the patient is also the authenticated principal, requesting via their PGO (see the MedMij example).
-- **IdentityClaim** (abstract): a typed assertion about the requester. Generalises rolcode, organisation identifiers, the system-role or business-role assertion, the Qualification, the Membership, and the two delegations. Each trust framework defines its own vocabulary.
+- **IdentityClaim** (abstract): a typed assertion about the requester. Generalises rolcode, organisation identifiers, the system-role or business-role assertion, the Qualification, the Membership, the UserAssertion, and the two standing delegations. Each trust framework defines its own vocabulary.
 - **Qualification**: the claim by which a ServiceProvider asserts that its product passed qualification for a given system role. The qualification itself is an upstream certification process; the claim asserts its result. AORTA records qualification results in TKID; a successful MedMij qualification admits the party into the DVA (provider-side) or DVP (PGO-side) role. Qualification here is product qualification: it certifies software for a system role. Professional competences (a nurse qualified for medicatie-toediening, say) are not Qualifications in this model; they travel as rolcodes or other identity claims and feed role resolution.
-- **HealthcareProfessional-to-HealthcareOrganization delegation**: the credential by which a professional delegates a set of business roles to their organisation. It is the _mandaattoken_ behind the matrix's `delegatable` flag. It is needed whenever the role is exercised by someone other than the professional who holds it: the organisation acting unattended, or an authenticated user who lacks the required rolcode and works under the professional's responsibility. A professional with the required rolcode asserts the role directly. Whether the delegation surfaces as a wire credential at all depends on the enforcement topology (below).
+- **UserAssertion**: the claim by which the system asserts which professional is acting: their identifier and rolcode, valid for the working session. It is the professional's short-lived delegation of their identity to the system they are logged into. Attended means a UserAssertion is present; the design notes work out how it relates to the standing delegations below.
+- **HealthcareProfessional-to-HealthcareOrganization delegation**: the credential by which a professional delegates a set of business roles to their organisation. It is the _mandaattoken_ behind the matrix's `delegatable` flag. It is needed whenever the role is exercised by someone other than the professional who holds it: the organisation acting unattended, or an authenticated user who lacks the required rolcode and works under the professional's responsibility. The delegation carries the professional's identifier and rolcode: under an unattended mandate it is the only claim that brings them, and role resolution reads the rolcode from it. A professional with the required rolcode asserts the role directly. Whether the delegation surfaces as a wire credential at all depends on the enforcement topology (below).
 - **ServiceProvider delegation**: the credential by which an organisation delegates a set of system roles to its service provider.
 - **Membership**: the claim by which a HealthcareOrganization asserts its admission to a trust framework, or to a specific information standard within it. The organisational counterpart of the Qualification: where the Qualification certifies a product for a system role, the Membership certifies that the organisation meets the framework's non-technical requirements (participation agreements, security and privacy norms). Realisations: the MedMij and Twiin deelnemersovereenkomst, AORTA's aansluitvoorwaarden. Prerequisites reference it like any other identity claim; it is slow-changing and typically binds at registration time.
 - **ContextClaim** (abstract) and **Enrollment**: assertions about the request and the patient, not the requester. `Enrollment` is the treatment relationship: the professional issues it to the organisation, attesting that they enrol or treat the patient. It feeds the use case's context checks, not role resolution.
 
-The delegation chain runs at two layers: the professional-to-organisation delegation at business-role level, the service-provider delegation at system-role level. Each step delegates only what it can express; a professional is not a system, so cannot delegate a system role. The identity claims feed the role resolution below; the context claims, such as the Enrollment, feed the use case's context checks.
+The delegation chain runs at two layers: the professional-to-organisation delegation at business-role level, the service-provider delegation at system-role level. Each step delegates only what it can express; a professional is not a system, so it cannot delegate a system role. The identity claims feed the role resolution below; the context claims, such as the Enrollment, feed the use case's context checks.
 
 ##### Role resolution and permission
 
@@ -90,7 +91,7 @@ The delegation chain runs at two layers: the professional-to-organisation delega
 
 The diagram shows two pipelines. Both start from the presented claims, and both end in the same thing: permission for one transaction. The business-role pipeline resolves the acting person's role and consults a policy; the system-role pipeline is a single check. The two pipelines are evaluated independently, in no particular order.
 
-**The business-role pipeline.** A `RolePrerequisite` resolves the presented identity claims to an `AuthorizationRole`: one business role refined by a set of claims, typically rolcodes. A role may have several prerequisites; satisfying any one resolves the role. The resolved role then meets the `PermissionMatrix`, which keys on (AuthorizationRole, Transaction) and yields allow or deny plus a `delegatable` flag. A slice of the AORTA medication matrix as illustration. Each row is one AuthorizationRole with its matrix verdict; the RolePrerequisites that resolve these roles (the rolcode sets) are separate registry entries, shown in the worked example:
+**The business-role pipeline.** A `RolePrerequisite` resolves the presented identity claims to an `AuthorizationRole`: one business role refined by a set of claims, typically rolcodes. A role may have several prerequisites; satisfying any one resolves the role. The resolved role is then looked up in the `PermissionMatrix`, which keys on (AuthorizationRole, Transaction) and yields allow or deny plus a `delegatable` flag. A slice of the AORTA medication matrix as illustration. Each row is one AuthorizationRole with its matrix verdict; the RolePrerequisites that resolve these roles (the rolcode sets) are separate registry entries, shown in the worked example:
 
 | AuthorizationRole                    | refines business role | Raadplegen medicatieafspraak | delegatable |
 | ------------------------------------ | --------------------- | ---------------------------- | ----------- |
@@ -103,7 +104,7 @@ The matrix is always present; its content may be trivial. For medication, AORTA 
 
 **The system-role pipeline.** One check: the Qualification and the ServiceProvider delegation must name the transaction's system role. The transaction itself declares which system role it involves, so naming the role is naming the permitted transactions; no matrix is needed. The business-role pipeline does need one, because a business role carries no per-transaction verdicts.
 
-One refinement exists, for standards whose system roles are coarse. Medicatieproces 9 defines roughly fifty system roles, one per subject-activity pair (e.g. `MedicatieafspraakRaadplegend`): naming the role pins down a single transaction. A standard with a handful of generic system roles would grant every transaction of the role with one qualification. For that case the trust framework MAY refine: a `QualifiedSystemRole` covers a subset of one system role's transactions, and the `SystemRolePrerequisite` resolves the ServiceProvider's claims to that refined role. Without a refinement, the qualification grants every transaction of the system role.
+One refinement exists, for standards whose system roles are coarse. Medicatieproces 9 defines roughly fifty system roles, one per subject-activity pair (e.g. `MedicatieafspraakRaadplegend`): naming the role pins down a single transaction. For a standard with a handful of generic system roles, one qualification would grant every transaction of the role. For that case the trust framework may refine: a `QualifiedSystemRole` covers a subset of one system role's transactions, and the `SystemRolePrerequisite` resolves the ServiceProvider's claims to that refined role. Without a refinement, the qualification grants every transaction of the system role.
 
 The model has two role constructs, and they answer different questions. An AuthorizationRole answers: which requesters may act in this business role? A QualifiedSystemRole answers: which transactions of this system role does the qualification cover? Side by side:
 
@@ -134,9 +135,9 @@ Some rules can only be evaluated while handling the request, because they read t
 
 The information-layer entity (`Transaction`) appears in yellow; trust-layer entities (`IdentityClaim`, `ServiceProvider`) in blue; realisation-layer entities, including the `Operation` and `FHIRResource`, in green.
 
-- **AccessTokenRequest**: what the ServiceProvider sends to the AS. Its `scope` parameter carries exactly one transaction identifier (the `tx`) and, optionally, operation identifiers (interactie-ids) that narrow the granted scopes. The request further carries the asserted identity claims and the context claims. The `patient` attribute carries the data-subject BSN where the transaction concerns a patient; the AS enforces that the patient identifier in the eventual query equals the issued AT's `patient` attribute.
+- **AccessTokenRequest**: what the ServiceProvider sends to the AS. Its `scope` parameter carries exactly one transaction identifier (the `tx`) and, optionally, operation identifiers (interactie-ids) that narrow the granted scopes. The request further carries the asserted identity claims and the context claims. The `patient` attribute carries the data-subject BSN where the transaction concerns a patient; the AS binds it at issuance, and the resource server (or a policy decision point in front of it) enforces that the patient identifier in the query equals the issued AT's `patient` attribute.
 - **AccessToken**: the OAuth 2.0 artefact returned on success. Authorizes exactly one transaction, carries the verified identity claims, and carries the granted SMART on FHIR scopes.
-- **SoFScope**: a [SMART on FHIR v2](https://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html) scope (`<context>/<Resource>.<crud>`). The unit of resource-server enforcement, granted at issuance from the requested operations via the profile and FHIR resource type. A scope MAY carry additional search parameters (e.g. `patient/Observation.rs?category=...`) where the operation-to-scope mapping defines them.
+- **SoFScope**: a [SMART on FHIR v2](https://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html) scope (`<context>/<Resource>.<crud>`). The unit of resource-server enforcement, granted at issuance from the requested operations via the profile and FHIR resource type. A scope may carry additional search parameters (e.g. `patient/Observation.rs?category=...`) where the operation-to-scope mapping defines them.
 
 Note the asymmetry between request and response: the **request carries the transaction identifier** (optionally narrowed by interactie-ids), the **response carries the transaction identifier plus the granted SMART on FHIR scopes**. The AS converts requested operations into scopes when it issues the AT.
 
@@ -189,7 +190,7 @@ Examples:
 aorta.tx.mp.verstrekkingsverzoek-raadplegen.3-0-0
 aorta.tx.mp.medicatieafspraak-beschikbaarstellen.3-0-0
 aorta.tx.mp.medicatieoverzicht-raadplegen.3-0-0
-medmij.tx.medicatie.medicatieafspraak-raadplegen.1-0
+medmij.tx.mp.medicatieafspraak-raadplegen.1-0
 ```
 
 Segment rules:
@@ -204,7 +205,7 @@ The use case the transaction belongs to is derivable from the catalogue and is n
 
 #### Operation identifier format
 
-Operations are the fine-grained interactie-ids that MAY appear in the request scope alongside the transaction identifier, to narrow the granted scopes for least-privilege. Each must name one of the operations that realise the scoped transaction (the AS verifies this at issuance), and omitting them requests all of the transaction's operations. The general shape is `<verb>:<artifact>:<version>` (e.g. `search:mp-MedicationAgreement:1`); the exact format is information-standard-specific and registered in the realisation catalogue. The segment rules and the registered prefixes are listed in the [appendix](#appendix-operation-identifier-format-details).
+Operations are the fine-grained interactie-ids that may appear in the request scope alongside the transaction identifier, to narrow the granted scopes for least-privilege. Each must name one of the operations that realise the scoped transaction (the AS verifies this at issuance), and omitting them requests all of the transaction's operations. The general shape is `<verb>:<artifact>:<version>` (e.g. `search:mp-MedicationAgreement:1`); the exact format is information-standard-specific and registered in the realisation catalogue. The segment rules and the registered prefixes are listed in the [appendix](#appendix-operation-identifier-format-details).
 
 #### Scope entries are opaque strings
 
@@ -222,7 +223,9 @@ For the purpose of policy matching, both the transaction identifier and the oper
 
 #### Conformance: issued AT
 
-> **REQ-5 (SHALL).** The transaction identifier SHALL appear in the AT's `scope` alongside the granted SMART on FHIR scopes. The `scope` member is standard in both JWT access tokens and introspection responses, so the transaction identifier is visible to the resource server and the audit subsystem without any non-standard field.
+> **REQ-5 (SHALL).** The transaction identifier SHALL appear in the AT's `scope` alongside the granted SMART on FHIR scopes.
+
+_Rationale: the `scope` member is standard in both JWT access tokens and introspection responses, so the transaction identifier is visible to the resource server and the audit subsystem without any non-standard field._
 
 #### Conformance: AS behaviour
 
@@ -236,7 +239,7 @@ For the purpose of policy matching, both the transaction identifier and the oper
 >
 > **REQ-8 (SHALL).** The context checks of the scoped transaction's use case SHALL be enforced before data is released. The trust framework SHALL declare, per use case, the enforcement point of each check: the AS at token issuance, the AS at token introspection, or a policy decision point at the resource server. The AS SHALL evaluate the checks declared for issuance before issuing the AT.
 >
-> **REQ-9 (SHALL).** The AS SHALL reject the request if the transaction is unknown, no PermissionMatrix entry permits the resolved AuthorizationRole, any check in REQ-7 fails, or any context check declared for issuance fails.
+> **REQ-9 (SHALL).** The AS SHALL reject the request if the transaction is unknown, any check in REQ-7 fails, or any context check declared for issuance fails.
 
 #### Identity claims, context, and verification
 
@@ -251,9 +254,9 @@ In current Dutch implementations these claims appear in several forms, sometimes
 
 Which claims a request must carry follows from the prerequisites: exactly those the scoped transaction's RolePrerequisite and SystemRolePrerequisite read to resolve the AuthorizationRole and the QualifiedSystemRole. There is no separate required-claims list to maintain.
 
-**Context checks.** Role resolution answers "who is the requester"; the context checks answer "is sharing this patient's data allowed". They evaluate ContextClaims about the request rather than the requester: the patient (BSN), the Enrollment (the treatment relationship), consent, and purpose-of-use. Purpose-of-use is the requester's declared purpose for the request; it is distinct from the legal basis (grondslag) that makes sharing lawful, although the declared purpose determines which legal basis must hold. The checks are attached to the use case because the claims they evaluate concern the intent, which all the use case's transactions share; attaching identical checks per transaction would only duplicate them. A trust framework MAY narrow the checks for an individual transaction, never loosen them. Because a transaction belongs to exactly one use case, the scoped transaction fixes which checks apply. Where each check is enforced is declared per use case (REQ-8); the design notes discuss that choice.
+**Context checks.** Role resolution answers "who is the requester"; the context checks answer "is sharing this patient's data allowed". They evaluate ContextClaims about the request rather than the requester: the patient (BSN), the Enrollment (the treatment relationship), consent, and purpose-of-use. Purpose-of-use is the requester's declared purpose for the request; it is distinct from the legal basis (grondslag) that makes sharing lawful, although the declared purpose determines which legal basis must hold. The checks are attached to the use case because the claims they evaluate concern the intent, which all the use case's transactions share; attaching identical checks per transaction would only duplicate them. A trust framework may narrow the checks for an individual transaction; it may never loosen them. Because a transaction belongs to exactly one use case, the scoped transaction fixes which checks apply. Where each check is enforced is declared per use case (REQ-8); the design notes discuss that choice.
 
-> **REQ-10 (SHALL).** The client SHALL present the identity claims needed to resolve the AuthorizationRole and the QualifiedSystemRole for the scoped transaction, together with the ContextClaims required by the context checks declared for issuance (the use case's checks, possibly narrowed for the scoped transaction). The AS SHALL verify role resolution, the matrix permission, and the issuance-declared context checks independently, and SHALL reject the request if any required claim is absent or any check fails.
+> **REQ-10 (SHALL).** The client SHALL present the identity claims needed to resolve the AuthorizationRole and the QualifiedSystemRole for the scoped transaction, together with the ContextClaims required by the context checks declared for issuance (the use case's checks, possibly narrowed for the scoped transaction). The AS verifies these claims under REQ-7 and REQ-8 and rejects under REQ-9; an absent required claim fails the check that reads it.
 
 ### Adoption
 
@@ -277,7 +280,7 @@ Open issue: custodianship of the shared vocabulary (this chapter) once more than
 
 {% include authorization-model-evaluation.svg %}
 
-Happy path. Any check failure results in rejection, not shown for clarity. The legend on the diagram marks each step's input sources: **R** for the AT request, **L1** for the information-layer catalogue, **L2** for the trust-layer registry, **L3** for the realisation-layer catalogue (the interactietabel). Steps that depend on derived context (e.g. "the required system role per operation") inherit their source from the step that resolved that context.
+Happy path. Any check failure results in rejection; failure paths are omitted for clarity. The legend on the diagram marks each step's input sources: **R** for the AT request, **L1** for the information-layer catalogue, **L2** for the trust-layer registry, **L3** for the realisation-layer catalogue (the interactietabel). Steps that depend on derived context (e.g. "the required system role per operation") inherit their source from the step that resolved that context.
 
 Because the AT is scoped to a single transaction, role resolution, the system-role coverage check, the matrix lookup, and the issuance-declared context checks are each evaluated once for that transaction; any operations in the request only narrow the granted scopes.
 
@@ -293,16 +296,18 @@ _This section is rationale, not specification: it argues the design decisions th
 - An _operation_ is too fine: it is a wire-level interactie-id used for least-privilege scope granting, below the grain at which permission is decided. It is also reusable across transactions, so an operation alone does not identify the intent.
 - An AT covers one activity the requester performs (one transaction, e.g. `Raadplegen verstrekkingsverzoek`). A request that needs several transactions at once (a full medication overview for one patient) is served by an overview transaction such as Medicatieoverzicht, itself one transaction, or by issuing several ATs.
 
-This makes the wire chattier, and that cost is accepted deliberately. A viewer that opens the full Medicatiebouwstenen use case touches seven raadplegen transactions and therefore needs seven token requests, each a round trip to the source-side AS (the AS is usually co-located with the RS). Three things bound the cost. The requests are independent, so they can be issued in parallel. The issued AT is cacheable per (transaction, patient) within its lifetime, so the volume is per viewer session, not per screen refresh. Batching several transactions into one AT was considered and rejected. The prerequisites and the context checks are per transaction. A bundled AT must either satisfy every bundled transaction's conditions at once, which fails entirely when one check fails (and checks can conflict: consent may cover one data category but not another), or be evaluated loosely at bundle level. Loose evaluation erodes the per-transaction granularity of consent and audit; it is exactly the implicit-scope pattern this proposal removes. How many ATs one wire exchange may issue is a layer-3 profiling choice (a framework can adopt a batching or token-exchange profile without touching the model), as long as each issued AT stays scoped to one transaction.
+This makes the wire chattier, and that cost is accepted deliberately. A viewer that opens the full Medicatiebouwstenen use case touches seven raadplegen transactions and therefore needs seven token requests, each a round trip to the source-side AS (the AS is usually co-located with the RS). Three things bound the cost. The requests are independent, so they can be issued in parallel. The issued AT is cacheable per (transaction, patient) within its lifetime, so the volume is per viewer session, not per screen refresh.
 
-#### Why consent, treatment relationship, and purpose are layer-2 constructs
+Batching several transactions into one AT was considered and rejected. The prerequisites and the context checks are per transaction. A bundled AT must either satisfy every bundled transaction's conditions at once, which fails entirely when one check fails (and checks can conflict: consent may cover one data category but not another), or be evaluated loosely at bundle level. Loose evaluation erodes the per-transaction granularity of consent and audit; it is exactly the ambiguity this proposal removes. How many ATs one wire exchange may issue is a layer-3 profiling choice (a framework can adopt a batching or token-exchange profile without touching the model), as long as each issued AT stays scoped to one transaction.
 
-The layer-2 constructs can be derived from the transaction dataset itself. A transaction carries a selection of dataset concepts, each optionally restricted: the concept holds a baseline conformance and cardinality, and the transaction may narrow them, never loosen. The kind of concept follows the transaction's direction. A query transaction (raadplegen) carries a `QueryParameters` group of identifiers and filters, project-specific. A delivery transaction (beschikbaarstellen, sturen) carries the zib payload; zibs enter as building-block datasets the payload concepts inherit from. That transaction dataset determines exactly what layer 2 can and cannot decide on. The bridge below maps the concepts of a query transaction onto the authorization constructs they touch.
+#### Why consent, treatment relationship, and purpose live in layer 2
+
+Before a source shares data, it decides on two kinds of information. The first kind is defined by the information standard: which data elements a transaction exchanges, which query parameters it accepts, and which values those parameters may take. Checking it needs no one's word, because the standard itself is the reference. This is layer 1. The second kind is facts the standard cannot contain: who the requester is, that the patient is under treatment, that the patient consented. Such a fact is valid only because a trusted party attests it: a claim. This is layer 2. Consent, the treatment relationship, and purpose-of-use are facts of the second kind, which is why they live in layer 2. The bridge below shows the split for a query transaction.
 
 {% include authorization-model-bridge.svg %}
 
-- **The patient identifier (BSN) is the data-subject join key.** It appears in the query parameters as a layer-1 concept, and layer 2 joins on it: the AS enforces that the BSN in the query equals the `patient` attribute of the access token, and the context claims (consent, treatment relationship) are about that same patient. Whether a patient is involved is itself a layer-1 fact: if the transaction dataset carries no patient identifier, there is no data-subject, the `patient` attribute on the access token is absent, and the patient-bound context claims do not apply.
-- **Consent, treatment relationship, and purpose are absent from the dataset.** No dataset concept carries them. That confirms they are layer-2 constructs: ContextClaims evaluated by the trust framework, not data the transaction exchanges. The consent check is the source's responsibility, whether against a national facility (Mitz) or a local consent registration; it is not part of the requester-provided claim set, and the diagram marks it separately.
+- **The BSN sits in both layers, because each layer asks a different question about it.** Layer 1 defines that the query names a patient. Whether the requester may ask about this particular patient is a layer-2 question: the AS binds the `patient` attribute at issuance, the resource server (or a policy decision point in front of it) checks that the BSN in the query equals that attribute, and the context claims (consent, treatment relationship) are about that same patient. Whether a patient is involved at all is a layer-1 fact: if the transaction dataset carries no patient identifier, there is no data subject, the `patient` attribute is absent, and the patient-bound context claims do not apply.
+- **The consent check is the source's responsibility.** Unlike the other context claims, consent is not presented by the requester: the source evaluates it itself, whether against a national facility (Mitz) or a local consent registration. The diagram marks it separately.
 
 Everything else in the query stays in layer 1: record-narrowing identifiers (a behandeling-id, a record-id) map to no layer-2 claim, and payload actor concepts (a record's prescriber) relate to the requester's identity claims in type only, never in instance.
 
@@ -322,9 +327,11 @@ _Which point for the context checks._ The context checks have no single right en
 
 The OAuth wire is asymmetric here: the request side has a claim-carrying convention (the AccessTokenRequest), the response side has none. A topology that wants a third party to verify source-side claims at response time therefore needs a wire convention that this proposal does not define. Verifying source-side claims at registration time or at token-issuance time avoids that gap, and fails before any data is assembled.
 
-#### Delegation lifetimes: standing and session
+#### One delegation mechanism, two uses
 
-Delegation has two lifetimes, and only one of them is a layer-2 credential. The _standing_ delegations (professional to organisation, organisation to service provider) change rarely and are governed by the matrix's `delegatable` flag and the qualification regime. The _session_ delegation, an authenticated user authorizing the system to act in their name for the duration of a session, is the authentication context itself; on the OAuth wire it is the grant behind the access token, not a credential the model adds. Attended means exactly that such a session delegation from an authenticated user exists; where it does not, a standing delegation must carry the role instead.
+Every delegation in this model is the same mechanism: a party authorizes another to act with its authority, for a bounded period. The professional uses it in two ways. Acting in person, the professional delegates the use of their identity to the system they are logged into; the system asserts this with a UserAssertion naming the professional and their rolcode, valid for the working session. Acting under mandate, the professional has delegated the business role itself to the organisation: standing, valid until revoked; whoever operates the system, or the system running unattended, acts in the professional's name.
+
+The two uses differ in duration and in what is conveyed (an identity versus a business role). The model keeps them apart for one reason only: under mandate the authenticated actor, if there is one, is not the role holder. The PermissionMatrix keys on that fact with its delegatable flag, and REQ-7 tests it. Attended means a UserAssertion is present. For the audit trail the distinction changes nothing: the source logs the acting individual where one exists, and the mandate where one is used.
 
 ### Examples
 
@@ -485,18 +492,19 @@ Translation table for the information-layer (L1) catalogue terms:
 | Qualification          | kwalificatie        |
 {:.grid .table-hover}
 
+- **AccessTokenRequest**: the OAuth 2.0 request sent by the ServiceProvider to the AS, carrying the transaction identifier (`tx`), optional operation identifiers, asserted identity claims, and context claims.
 - **AS**: Authorization Server, issues access tokens.
 - **AT**: Access Token.
-- **AccessTokenRequest**: the OAuth 2.0 request sent by the ServiceProvider to the AS, carrying the transaction identifier (`tx`), optional operation identifiers, asserted identity claims, and context claims.
 - **AuthorizationRole**: the subject the PermissionMatrix keys on; one business role refined by a set of identity claims (typically rolcodes), resolved from presented claims by a RolePrerequisite.
 - **Business role** (bedrijfsrol): the role a person plays in a transaction (Voorschrijver, Verstrekker, Toediener, ...). Unit of HealthcareProfessional-to-HealthcareOrganization delegation, and the role an AuthorizationRole refines.
+- **Context check**: a per-use-case rule that evaluates ContextClaims; its enforcement point (AS at issuance, AS at introspection, or a policy decision point at the resource server) is declared per use case (REQ-8).
+- **ContextClaim**: a typed assertion about the request context rather than the requester (patient, Enrollment, consent, purpose-of-use), evaluated by the use case's context checks.
+- **Credential**: a set of one or more claims made by an issuer, in the W3C Verifiable Credentials sense of the term (not the NIST sense). This chapter writes credential where claims travel bundled as one artefact (the two delegations) and claim for a single assertion.
 - **Dataset**: a tree of dataset concepts; either a primary dataset of an information standard or an imported building-block dataset (such as a zib).
 - **DatasetConcept**: one node of a dataset (a group or an item), carrying a baseline conformance and cardinality that a transaction may restrict.
 - **DEZI**: the successor programme to the UZI register for identifying healthcare professionals; it keeps the identifier and rolcode concepts. This chapter uses UZI/rolcode terminology.
-- **IdentityClaim**: a typed assertion about the requester that the policy evaluates. Carried in many wire formats (signed SAML claim, Verifiable Credential, JWT claim by a trusted AS, mTLS-derived claim, ...).
-- **Context check**: a per-use-case rule that evaluates ContextClaims; its enforcement point (AS at issuance, AS at introspection, or a policy decision point at the resource server) is declared per use case (REQ-8).
-- **ContextClaim**: a typed assertion about the request context rather than the requester (patient, Enrollment, consent, purpose-of-use), evaluated by the use case's context checks.
 - **Enrollment**: a ContextClaim for the patient's treatment relationship; the professional issues it to the organisation, attesting that they enrol or treat the patient.
+- **IdentityClaim**: a typed assertion about the requester that the policy evaluates. Carried in many wire formats (signed SAML claim, Verifiable Credential, JWT claim by a trusted AS, mTLS-derived claim, ...).
 - **Information layer (L1)**: the layer of the information standards; the Nictiz catalogue of use cases, transactions, roles, and datasets.
 - **Information standard** (informatiestandaard): a healthcare information standard (e.g. Medicatieproces, BgZ), in the Netherlands mostly maintained by Nictiz.
 - **Legal basis** (grondslag): the legal ground that makes sharing lawful (consent, treatment relationship, statutory duty). Distinct from purpose-of-use.
@@ -515,12 +523,13 @@ Translation table for the information-layer (L1) catalogue terms:
 - **System role** (systeemrol): the role a system plays in a transaction (Sturend, Ontvangend, Raadplegend, Beschikbaarstellend). Unit of qualification and of ServiceProvider delegation.
 - **SystemRolePrerequisite**: a layer 2 rule that resolves a ServiceProvider's claims (notably its Qualification and delegation) to a QualifiedSystemRole; the system-role counterpart of a RolePrerequisite, with no matrix.
 - **Transaction** (transactie): a single interaction within a transaction group, e.g. `Raadplegen verstrekkingsverzoek` (the consumer queries a source) or `Beschikbaarstellen verstrekkingsverzoeken` (the source returns the requested data). The leaf functional unit of layer 1 and the unit the PermissionMatrix authorizes against; belongs to exactly one use case. Not to be confused with the FHIR transaction interaction (an atomic `Bundle` POST), which appears as a verb in operation tokens.
-- **Transaction group** (transactiegroep): a named group of related transactions, e.g. `Verstrekkingsverzoek (raadplegen/beschikbaarstellen)`.
 - **Transaction dataset** (transactiedataset): the subset of dataset concepts a transaction selects, each optionally restricted (conformance, cardinality, condition) relative to its baseline.
+- **Transaction group** (transactiegroep): a named group of related transactions, e.g. `Verstrekkingsverzoek (raadplegen/beschikbaarstellen)`.
 - **Transaction identifier**: the identifier of the scoped transaction, carried in the OAuth `scope` of the AT request and the issued AT; format `<governance-body>.tx.<information-standard>.<transaction>.<version>`.
 - **Trust framework**: an independently governed set of agreements for data exchange (afsprakenstelsel).
 - **Trust layer (L2)**: the layer of the trust-framework constructs: role resolution, the permission matrix, qualifications, delegations, identity and context claims.
 - **Use case**: a sub-chapter of an information standard. A catalogue grouping of transaction groups; defines the intent and the context checks; not carried on the wire.
+- **UserAssertion**: the IdentityClaim by which the system asserts the acting professional's identity and rolcode, valid for the working session; the professional's short-lived delegation of their identity to the system. Attended means a UserAssertion is present.
 - **Zib**: _zorginformatiebouwsteen_, a Dutch healthcare data model construct, published as a building-block dataset.
 
 ### References

--- a/input/pagecontent/authorization-model.md
+++ b/input/pagecontent/authorization-model.md
@@ -8,9 +8,9 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 Dutch healthcare data exchange runs under several trust frameworks (AORTA-on-FHIR, MedMij, Twiin, Nuts use-case communities). Each one has, over time, built its own authorization model. Each model is well documented within its own framework. But it is framework-local: it lives spread over registry definitions, policy documents, and wire conventions, in a vocabulary that only works inside that framework. No shared national model exists. The models overlap conceptually: qualifications, delegations, roles, and context checks appear in all of them. Yet they never align, and there is no shared vocabulary to compare them in.
 
-This proposal makes the model explicit. It defines a shared _authorization information model_, layered on top of the Nictiz information-standard catalogue, and derives one concrete OAuth 2.0 wire convention from it.
+This proposal makes the model explicit. Its goal is twofold. First, it defines a shared _authorization information model_ in which each trust framework can express its own policies, layered on top of the Nictiz information-standard catalogue as the common basis. Second, it derives from that model one OAuth 2.0 convention for requesting access tokens, so that the frameworks share a wire format where they interoperate.
 
-The intended audience is architects of the trust frameworks listed above. The proposal is independent of how identity claims are attested and does not prescribe a wire format; the Specification lists the attestation forms in use today.
+The intended audience is architects of the trust frameworks listed above. The chapter is discussion input for alignment with those frameworks, not settled policy. The token request convention is the one wire format this chapter does prescribe; the proposal is independent of how identity claims are attested and does not prescribe a wire format for them. The Specification lists the attestation forms in use today.
 
 A note on terminology: this chapter uses English terms for the Nictiz catalogue concepts (transaction, system role, business role); the glossary contains the translation table. Concrete catalogue values (transaction names, role names, rolcodes) are quoted in their original Dutch.
 
@@ -21,11 +21,11 @@ Each trust framework documents its own authorization model, but only its own. Fo
 - **Qualification**: every framework has a mechanism that admits a vendor product into a technical role, but each framework names a different part of that mechanism. AORTA names the registry that records the result of a successful qualification (TKID); MedMij names the roles a successful qualification admits a party into (DVA, DVP); Twiin has similar mechanisms. None separates the qualification from the role it leads to.
 - **Delegation chain**: AORTA, MedMij, and Twiin each construct delegation chains between professionals, organisations, and service providers differently. The chain shape is usually similar; the attestations and granularities are not.
 - **Role resolution**: every framework maps presented identity claims (rolcodes, organisation identifiers) onto something it permits actions for, but the mapping rules are buried in framework-specific policy documents such as the Autorisatierichtlijn, with no common structure.
-- **Context checks**: consent (Mitz), the treatment relationship, and purpose-of-use gates exist everywhere, attached at different points in each framework and with no shared vocabulary (an explicit purposeOfUse field in the Nuts authorization credential, the distinct spoed situation in Mitz).
+- **Context checks**: consent (Mitz), the treatment relationship, and purpose-of-use conditions exist everywhere, attached at different points in each framework and with no shared vocabulary (an explicit purposeOfUse field in the Nuts authorization credential, the distinct spoed situation in Mitz).
 
-Because each model is stated only in its own framework's terms, the models cannot be compared, mapped, or composed. A developer building a system that participates in two frameworks must assemble two complete models from documentation scattered across wikis, registries, and policy documents, and invent the mapping between them. A policy author cannot tell whether two frameworks make the same access decision for the same situation. This is the core problem: cross-framework integration is expensive and brittle.
+Because each model is stated only in its own framework's terms, the models cannot be compared, mapped, or composed. A developer building a system that participates in two frameworks must assemble two complete models from documentation scattered across wikis, registries, and policy documents, and invent the mapping between them. A policy author cannot tell whether two frameworks make the same access decision for the same situation. Cross-framework integration is expensive and brittle; authorization is not the only reason, but it is the part this chapter addresses.
 
-The divergence is most visible on the OAuth wire: each framework identifies the authorized work in the request scope with a different grammar, and differs in whether that identification survives onto the issued access token. The wire divergence is only the visible part: the grammars differ because each framework derived its wire convention from a different underlying model. Aligning the syntax without aligning the model would change nothing. This proposal therefore defines the model first, and the wire convention as its consequence.
+The divergence is most visible on the wire. The frameworks do not even share one protocol family: AORTA's current interfaces carry SAML tokens, the others use OAuth 2.0. Where OAuth is used, each framework identifies the authorized work in the request scope with a different grammar, and differs in whether that identification survives onto the issued access token. The wire divergence is only the visible part: the grammars differ because each framework derived its wire convention from a different underlying model. Aligning the syntax without aligning the model would change nothing. This proposal therefore defines the model first, and the wire convention as its consequence.
 
 ### The model
 
@@ -35,9 +35,9 @@ The Examples section shows every construct introduced below as a filled-in table
 
 This proposal models authorization in three layers. The layering is a modelling decision, not a given: it is chosen because the layers have different owners, change at different rates, and answer different questions. A layer groups concerns, not authors; one governance body can author artefacts in more than one layer.
 
-- **Layer 1, Information Standards** (the _information layer_) defines _what_ transactions exist and _what data_ they carry. In the Netherlands most information standards are maintained by Nictiz; this proposal adopts the Nictiz meta-model, per the [Handleiding Wiki documentatie](https://informatiestandaarden.nictiz.nl/wiki/Handleiding_Wiki_documentatie), as the layer-1 vocabulary. It catalogues information standards, use cases, transaction groups, transactions, system roles, business roles, and the datasets they operate on. The same for all trust frameworks.
+- **Layer 1, Information Standards** (the _information layer_) defines _what_ transactions exist and _what data_ they carry. In the Netherlands most information standards are maintained by Nictiz; this proposal adopts the Nictiz meta-model, per the [Handleiding Wiki documentatie](https://informatiestandaarden.nictiz.nl/wiki/Handleiding_Wiki_documentatie), as the layer-1 vocabulary. It catalogues information standards, use cases, transaction groups, transactions, system roles, business roles, and the datasets they operate on. The data definitions (datasets, zibs) are part of this layer; there is no separate data layer. The same for all trust frameworks.
 - **Layer 2, Trust Framework** (the _trust layer_) specifies _who_ may perform _which_ transactions, and under what conditions: role resolution, the permission matrix, qualifications, the delegation chain, identity claims, context claims. Today these constructs are filled per framework (VZVZ, MedMij, Twiin, Nuts-toepassingen). The model does not tie them to per-framework governance: with a shared vocabulary, layer-2 policies can be lifted to national governance where that is wanted.
-- **Layer 3, Realisation and OAuth wire** (the _realisation layer_) specifies _how_ a transaction reaches the wire: the FHIR profiles that represent its data, the wire-level operations that carry it, and how a single authorization decision surfaces in an OAuth 2.0 exchange. The wire artefacts are the access-token request, the issued access token, and the minted SMART on FHIR scopes that the resource server enforces.
+- **Layer 3, Realisation** (the _realisation layer_) specifies _how_ a transaction reaches the wire: the FHIR profiles that represent its data, the wire-level operations that carry it, and how a single authorization decision surfaces in an OAuth 2.0 exchange. The wire artefacts are the access-token request, the issued access token, and the granted scopes that the resource server enforces. This proposal realises the granted scopes as SMART on FHIR v2 scopes; the model does not depend on that choice.
 
 This proposal defines a uniform model for layers 2 and 3. Layer 1 is taken as given.
 
@@ -55,33 +55,34 @@ Hierarchy from outer to inner:
 - **Business role** (bedrijfsrol): the role a person plays in a transaction (Voorschrijver, Verstrekker, ...). Cross-cutting actor type.
 - **Dataset** and **DatasetConcept**: the data definitions. An information standard defines its primary datasets; building-block datasets (zibs) are defined by other standards and imported. A dataset is a tree of concepts (groups and items); a transaction selects a subset of those concepts and restricts them. That selection is the _transaction dataset_ (transactiedataset).
 
-Two structural points matter for authorization:
+Three structural points matter for authorization:
 
 - **Containment, not reuse.** A transaction group belongs to one use case, and a transaction to one transaction group, so a transaction belongs to exactly one use case. Reuse across standards happens at the dataset, template, and value-set level, not at the transaction level. Fetching the same data under a different use case is, by definition, a different transaction, because the use case carries the intent and therefore the conditions.
 - **There is no operation concept in layer 1.** The functional model stops at the transaction. The fine-grained wire-level operations are realisation constructs and are introduced in layer 3.
+- **Lifecycle rules are layer-1 facts.** Where an information standard defines a lifecycle for its data (status values and the permitted transitions), that state machine belongs to this layer. It surfaces in authorization as state rules on layer-3 operations, enforced by the resource server at request time; layer 3 works out why such rules never ride the access token.
 
 The transaction dataset itself shows which constructs belong in layer 2; the design notes contain that derivation.
 
 #### Layer 2: Trust Framework
 
-The trust layer (L2) adds the constructs that gate access on top of the information layer (L1) catalogue. It is presented in two views: first the concrete actors and the credentials that carry their claims in the Dutch context, then the general mechanism that turns those claims into an access decision. In both diagrams, information-layer entities are shown in yellow (referenced, not redefined here), trust-layer policy and actors in pale blue, and claims in mid-blue, typed by their `<<IdentityClaim>>` or `<<ContextClaim>>` stereotype.
+The trust layer (L2) adds the constructs that control access on top of the information layer (L1) catalogue. It is presented in two views: first the concrete actors and the credentials that carry their claims in the Dutch context, then the general mechanism that turns those claims into an access decision. In both diagrams, information-layer entities are shown in yellow (referenced, not redefined here), trust-layer policy and actors in pale blue, and claims in mid-blue, typed by their `<<IdentityClaim>>` or `<<ContextClaim>>` stereotype.
 
 ##### Actors and credentials
 
-This view shows who the actors are, the credentials carrying the identity claims that the access decision consumes, and the context claims (such as the Enrollment) the actors produce.
+This view shows who the actors are, the credentials carrying the identity claims that the access decision consumes, and the context claims (such as the Enrollment) the actors produce. Requests reach a source through one of two channels: in the _professional channel_ a ServiceProvider requests on behalf of a professional and their organisation; in the _patient channel_ the patient requests their own data through a PGO. The actors below cover both.
 
 {% include authorization-model-layer2.svg %}
 
-- **HealthcareProfessional, HealthcareOrganization, ServiceProvider**: the three professional-side actor layers. The professional is employed by an organisation; the organisation is served by a service provider.
-- **Patient**: the data subject, referenced via their BSN in the `patient` attribute of the AccessTokenRequest. In professional flows the request principal is the ServiceProvider acting for the professional and the organisation; in patient-channel (PHR) flows the patient is also the authenticated principal, requesting via their PGO (see the MedMij example).
+- **HealthcareProfessional, HealthcareOrganization, ServiceProvider**: the three actor layers of the professional channel. The professional is employed by an organisation; the organisation is served by a service provider. The model names healthcare organisations because the trust frameworks do; organisations outside care are out of scope here, though the mechanism does not preclude them.
+- **Patient**: the data subject, referenced via their BSN in the `patient` attribute of the AccessTokenRequest. In the professional channel the request principal is the ServiceProvider acting for the professional and the organisation; in the patient channel the patient is also the authenticated principal, requesting via their PGO (see the MedMij example).
 - **IdentityClaim** (abstract): a typed assertion about the requester. Generalises rolcode, organisation identifiers, the system-role or business-role assertion, the Qualification, the Membership, and the two delegations. Each trust framework defines its own vocabulary.
-- **Qualification**: the claim by which a ServiceProvider asserts that its product passed qualification for a given system role. The qualification itself is an upstream certification process; the claim asserts its result. AORTA records qualification results in TKID; a successful MedMij qualification admits the party into the DVA (provider-side) or DVP (PGO-side) role.
+- **Qualification**: the claim by which a ServiceProvider asserts that its product passed qualification for a given system role. The qualification itself is an upstream certification process; the claim asserts its result. AORTA records qualification results in TKID; a successful MedMij qualification admits the party into the DVA (provider-side) or DVP (PGO-side) role. Qualification here is product qualification: it certifies software for a system role. Professional competences (a nurse qualified for medicatie-toediening, say) are not Qualifications in this model; they travel as rolcodes or other identity claims and feed role resolution.
 - **HealthcareProfessional-to-HealthcareOrganization delegation**: the credential by which a professional delegates a set of business roles to their organisation. It is the _mandaattoken_ behind the matrix's `delegatable` flag. It is needed whenever the role is exercised by someone other than the professional who holds it: the organisation acting unattended, or an authenticated user who lacks the required rolcode and works under the professional's responsibility. A professional with the required rolcode asserts the role directly. Whether the delegation surfaces as a wire credential at all depends on the enforcement topology (below).
 - **ServiceProvider delegation**: the credential by which an organisation delegates a set of system roles to its service provider.
 - **Membership**: the claim by which a HealthcareOrganization asserts its admission to a trust framework, or to a specific information standard within it. The organisational counterpart of the Qualification: where the Qualification certifies a product for a system role, the Membership certifies that the organisation meets the framework's non-technical requirements (participation agreements, security and privacy norms). Realisations: the MedMij and Twiin deelnemersovereenkomst, AORTA's aansluitvoorwaarden. Prerequisites reference it like any other identity claim; it is slow-changing and typically binds at registration time.
-- **ContextClaim** (abstract) and **Enrollment**: assertions about the request and the patient, not the requester. `Enrollment` is the treatment relationship: the professional issues it to the organisation, attesting that they enrol or treat the patient. It feeds the use-case context gate, not role resolution.
+- **ContextClaim** (abstract) and **Enrollment**: assertions about the request and the patient, not the requester. `Enrollment` is the treatment relationship: the professional issues it to the organisation, attesting that they enrol or treat the patient. It feeds the use case's context checks, not role resolution.
 
-The delegation chain runs at two layers: the professional-to-organisation delegation at business-role level, the service-provider delegation at system-role level. Each step delegates only what it can express; a professional is not a system, so cannot delegate a system role. The identity claims feed the role resolution below; the context claims, such as the Enrollment, feed the use-case context gate.
+The delegation chain runs at two layers: the professional-to-organisation delegation at business-role level, the service-provider delegation at system-role level. Each step delegates only what it can express; a professional is not a system, so cannot delegate a system role. The identity claims feed the role resolution below; the context claims, such as the Enrollment, feed the use case's context checks.
 
 ##### Role resolution and permission
 
@@ -89,7 +90,7 @@ The delegation chain runs at two layers: the professional-to-organisation delega
 
 The diagram shows two pipelines. Both start from the presented claims, and both end in the same thing: permission for one transaction. The business-role pipeline resolves the acting person's role and consults a policy; the system-role pipeline is a single check. The two pipelines are evaluated independently, in no particular order.
 
-**The business-role pipeline.** A `RolePrerequisite` resolves the presented identity claims to an `AuthorizationRole`: one business role refined by a set of claims, typically rolcodes. A role may have several prerequisites; satisfying any one resolves the role. The resolved role then meets the `PermissionMatrix`, which keys on (AuthorizationRole, Transaction) and yields allow or deny plus a `delegatable` flag. A slice of the AORTA medication matrix as illustration (the worked example shows the full registry):
+**The business-role pipeline.** A `RolePrerequisite` resolves the presented identity claims to an `AuthorizationRole`: one business role refined by a set of claims, typically rolcodes. A role may have several prerequisites; satisfying any one resolves the role. The resolved role then meets the `PermissionMatrix`, which keys on (AuthorizationRole, Transaction) and yields allow or deny plus a `delegatable` flag. A slice of the AORTA medication matrix as illustration. Each row is one AuthorizationRole with its matrix verdict; the RolePrerequisites that resolve these roles (the rolcode sets) are separate registry entries, shown in the worked example:
 
 | AuthorizationRole                    | refines business role | Raadplegen medicatieafspraak | delegatable |
 | ------------------------------------ | --------------------- | ---------------------------- | ----------- |
@@ -104,7 +105,7 @@ The matrix is always present; its content may be trivial. For medication, AORTA 
 
 One refinement exists, for standards whose system roles are coarse. Medicatieproces 9 defines roughly fifty system roles, one per subject-activity pair (e.g. `MedicatieafspraakRaadplegend`): naming the role pins down a single transaction. A standard with a handful of generic system roles would grant every transaction of the role with one qualification. For that case the trust framework MAY refine: a `QualifiedSystemRole` covers a subset of one system role's transactions, and the `SystemRolePrerequisite` resolves the ServiceProvider's claims to that refined role. Without a refinement, the qualification grants every transaction of the system role.
 
-The two layer-2 roles compare as follows:
+The model has two role constructs, and they answer different questions. An AuthorizationRole answers: which requesters may act in this business role? A QualifiedSystemRole answers: which transactions of this system role does the qualification cover? Side by side:
 
 |                 | AuthorizationRole                | QualifiedSystemRole                               |
 | --------------- | -------------------------------- | ------------------------------------------------- |
@@ -117,34 +118,37 @@ The two layer-2 roles compare as follows:
 
 ##### The patient channel
 
-The same machinery covers the citizen. The patient is an actor whose RolePrerequisite reads the DigiD-authenticated BSN claim and resolves to an AuthorizationRole refining the business role Patiënt. The PermissionMatrix rows for that role are the framework's allow-set for patient access (in MedMij terms: the gegevensdiensten). The system-role pipeline is unchanged: the PGO operator is the ServiceProvider, its Qualification is the DVP admission, and the delegation is issued by the patient rather than by an organisation. The context gate degenerates: there is no treatment relationship, and consent is inherent in requesting one's own data. What remains is the data-subject equality check: the authenticated BSN must equal the `patient` attribute. The MedMij example in the Examples section shows the resulting token.
+The same machinery covers the citizen. The patient is an actor whose RolePrerequisite reads the DigiD-authenticated BSN claim and resolves to an AuthorizationRole refining the business role Patiënt. The PermissionMatrix rows for that role are the framework's allow-set for patient access (in MedMij terms: the gegevensdiensten). The system-role pipeline is unchanged: the PGO operator is the ServiceProvider, its Qualification is the DVP admission, and the delegation is issued by the patient rather than by an organisation. Most of the context checks do not apply in this channel: there is no treatment relationship, and consent is inherent in requesting one's own data. What remains is the data-subject equality check: the authenticated BSN must equal the `patient` attribute. The MedMij example in the Examples section shows the resulting token.
 
 ##### Enforcement topology
 
-The model defines policy as facts and rules: claims, prerequisites, the matrix, the context gate. Where those rules are enforced, and how the evidence reaches the enforcer, is a deployment choice the model leaves open. The principle: a fact must surface as a wire claim exactly when the evaluating party cannot observe it directly. The consequences (why the two delegations behave differently, when evidence should bind, what the OAuth wire can and cannot carry) are worked out in the design notes, after the evaluation flow.
+The model defines policy as facts and rules: claims, prerequisites, the matrix, the context checks. Where those rules are enforced, and how the evidence reaches the enforcer, is a deployment choice the model constrains but does not fix. Two principles govern that choice. First, a granted scope is a decision, not a forwarded claim: by granting the transaction in the AT's scope, the AS asserts that the authorization decision was made. The holder of an issued AT can expect it to be accepted as-is at runtime; the resource server may still refuse the request itself, but only on checks whose inputs did not exist at issuance, such as state rules. Second, a fact must surface as a wire claim exactly when the evaluating party cannot observe it directly. The first principle splits the checks by input availability: the identity and permission checks bind at issuance (REQ-7), each context check's enforcement point is declared per use case (REQ-8), and state rules always evaluate at the resource server. The consequences (why the two delegations behave differently, when evidence should bind, what the OAuth wire can and cannot carry) are worked out in the design notes, after the evaluation flow.
 
-#### Layer 3: Realisation and OAuth wire
+#### Layer 3: Realisation
 
-The realisation layer (L3) turns the transaction into FHIR and OAuth artefacts. Its first construct is the **Operation**: a single wire-level interaction, identified as `<verb>:<artifact>:<version>` (e.g. `search:mp-MedicationAgreement:1`). Operations are reusable building blocks: the same operation can realise transactions in different use cases. One transaction is realised by one or more operations, and each operation targets one FHIR resource type, which is what SMART on FHIR scopes are minted from. The construct is not new: the [AORTA-on-FHIR interactietabel](https://aorta-on-fhir.public.vzvz.nl/aorta-on-fhir-specificaties/Working-version/aorta-interactietabel) defines the same thing as its `interactionId`, including the reuse across use cases (one operation row carrying a list of context codes); this proposal adopts that shape.
+The realisation layer (L3) turns the transaction into FHIR and OAuth artefacts. Its first construct is the **Operation**: a single wire-level interaction, identified as `<verb>:<artifact>:<version>` (e.g. `search:mp-MedicationAgreement:1`). Operations are reusable building blocks: the same operation can realise transactions in different use cases. One transaction is realised by one or more operations, and each operation targets one FHIR resource type, from which the granted scopes derive. The construct is not new: the [AORTA-on-FHIR interactietabel](https://aorta-on-fhir.public.vzvz.nl/aorta-on-fhir-specificaties/Working-version/aorta-interactietabel) defines the same thing as its `interactionId`, including the reuse across use cases (one operation row carrying a list of context codes); this proposal adopts that shape.
+
+Some rules can only be evaluated while handling the request, because they read the current state of the data. The Task workflow of a notified-pull exchange is the clearest example: whether the receiver may set a Task to `accepted` depends on the status the Task has now. This proposal calls these _state rules_ and defines them on layer 1, in plain text: the information standard states, per transaction, which role may perform which operation in which data state. For the eOverdracht Task: "the receiving organisation may move a Task from `requested` to `accepted` or `rejected`; it may not move a Task in any other state." The Nictiz meta-model has no formal construct for this today; plain text on the transaction suffices until it does. The realisation catalogue lists the state rules next to the operations they constrain, and the resource server enforces them while handling the request. How a resource server implements the check is out of scope: it depends on its technical stack. The access token never carries state rules, because the state they read does not exist at issuance. _(Draft: the eOverdracht wording above is illustrative; to be verified against the eOverdracht and Twiin realisations.)_
 
 {% include authorization-model-layer3.svg %}
 
 The information-layer entity (`Transaction`) appears in yellow; trust-layer entities (`IdentityClaim`, `ServiceProvider`) in blue; realisation-layer entities, including the `Operation` and `FHIRResource`, in green.
 
-- **AccessTokenRequest**: what the ServiceProvider sends to the AS. Carries one transaction scope token (the `tx`), an optional list of operations (interactie-ids) that narrow the minted scopes, the asserted identity claims, and the context claims. The `patient` attribute carries the data-subject BSN where the transaction concerns a patient; the AS enforces that the patient identifier in the eventual query equals the issued token's `patient` scope.
-- **AccessToken**: the OAuth 2.0 artefact returned on success. Authorizes exactly one transaction, carries the verified identity claims, and carries the minted SMART on FHIR scopes.
-- **SoFScope**: a [SMART on FHIR v2](https://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html) scope (`<context>/<Resource>.<crud>`). The unit of resource-server enforcement, minted at issue time from the requested operations via the profile and FHIR resource type.
+- **AccessTokenRequest**: what the ServiceProvider sends to the AS. Its `scope` parameter carries exactly one transaction identifier (the `tx`) and, optionally, operation identifiers (interactie-ids) that narrow the granted scopes. The request further carries the asserted identity claims and the context claims. The `patient` attribute carries the data-subject BSN where the transaction concerns a patient; the AS enforces that the patient identifier in the eventual query equals the issued AT's `patient` attribute.
+- **AccessToken**: the OAuth 2.0 artefact returned on success. Authorizes exactly one transaction, carries the verified identity claims, and carries the granted SMART on FHIR scopes.
+- **SoFScope**: a [SMART on FHIR v2](https://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html) scope (`<context>/<Resource>.<crud>`). The unit of resource-server enforcement, granted at issuance from the requested operations via the profile and FHIR resource type. A scope MAY carry additional search parameters (e.g. `patient/Observation.rs?category=...`) where the operation-to-scope mapping defines them.
 
-Note the asymmetry between request and response: the **request carries the transaction token** (optionally narrowed by interactie-ids), the **response carries the transaction token plus the minted SMART on FHIR scopes**. The AS converts requested operations into scopes at mint time.
+Note the asymmetry between request and response: the **request carries the transaction identifier** (optionally narrowed by interactie-ids), the **response carries the transaction identifier plus the granted SMART on FHIR scopes**. The AS converts requested operations into scopes when it issues the AT.
 
-An AT is scoped to one transaction. The AS verifies that a resolved QualifiedSystemRole (backed by the Qualification and the ServiceProvider delegation) covers the transaction. Operations in the request only narrow the minted scopes. Why the transaction, and not the use case or the operation, is the scope unit is argued in the design notes.
+An AT is scoped to one transaction. The AS verifies that a resolved QualifiedSystemRole (backed by the Qualification and the ServiceProvider delegation) covers the transaction. Operations in the request only narrow the granted scopes. Why the transaction, and not the use case or the operation, is the scope unit is argued in the design notes.
 
-Two mappings make this work, and both live in a realisation catalogue published alongside the trust framework's registry:
+Three mappings make this work, all living in a realisation catalogue published alongside the trust framework's registry:
 
 - transaction to operations: which operations realise which transaction. The AS uses it to validate requested operations (REQ-4).
-- operation to scope: operation to profile to FHIR resource type to SMART on FHIR scope. The AS uses it at mint time.
+- operation to scope: operation to profile to FHIR resource type to SMART on FHIR scope. The AS uses it when granting scopes.
+- operation to state rules: the plain-text state rules from the information standard, listed next to the operations they constrain. The resource server uses them while handling the request; the AS does not.
 
-The catalogue is owned by whoever realises the information standard for the framework. Today it exists per framework, the interactietabel being one realisation. The model requires only that it is published and that the AS resolves both mappings by lookup, not derivation.
+The catalogue is owned by whoever realises the information standard for the framework. Today it exists per framework, the interactietabel being one realisation. The model requires only that it is published and that the AS resolves its mappings by lookup, not derivation.
 
 ### Specification
 
@@ -167,12 +171,13 @@ The normative model for layers 2 and 3 is the one shown in the Layer 2 and Layer
 - A trust framework MAY require a Membership claim (organisational admission to the framework or an information standard) for the HealthcareOrganization; prerequisites reference it like any other identity claim.
 - An AccessTokenRequest SHALL be scoped to exactly one Transaction and MAY narrow to a subset of the operations that realise that transaction.
 - An AccessToken SHALL authorize exactly one Transaction.
+- A realisation catalogue MAY list state rules per operation, taken from the information standard's lifecycle; where it does, the resource server SHALL enforce them while handling the request.
 
 Trust frameworks MAY use additional concepts beyond these (framework-specific governance entities, for example), but SHALL NOT redefine the meaning of the concepts above.
 
-#### Transaction scope token
+#### Transaction identifier
 
-Every AT request defines exactly one transaction scope token with the format:
+Every AT request carries exactly one _transaction identifier_ in its `scope` parameter, with the format below. (RFC 6749 calls each space-separated entry in `scope` a scope-token; this chapter reserves the word token for the access token and writes identifier.)
 
 ```
 <governance-body>.tx.<information-standard>.<transaction>.<version>
@@ -190,49 +195,48 @@ medmij.tx.medicatie.medicatieafspraak-raadplegen.1-0
 Segment rules:
 
 - `<governance-body>`: the body governing the namespace (`aorta`, `medmij`, `twiin`, `nuts`, ...).
-- `tx`: literal marker, identifying the token as a transaction scope token.
+- `tx`: literal marker, identifying this scope entry as a transaction identifier.
 - `<information-standard>`: the information-standard slug within the governance body (`mp` for Medicatieproces, `bgz`, `eoverdracht`, ...).
 - `<transaction>`: kebab-case transaction identifier (e.g. `verstrekkingsverzoek-raadplegen`).
 - `<version>`: hyphen-separated semantic version (`3-0-0`), or a single integer for major-only versioning (`3`). No `v` prefix, to match the operation token format below.
 
 The use case the transaction belongs to is derivable from the catalogue and is not carried on the wire.
 
-#### Operation token format
+#### Operation identifier format
 
-Operations are the fine-grained interactie-ids that MAY appear in the request scope alongside the transaction token, to narrow the scopes minted from it for least-privilege. Each must belong to the scoped transaction's realisation (the AS verifies this at mint time), and omitting them requests all of the transaction's operations. The general shape is `<verb>:<artifact>:<version>` (e.g. `search:mp-MedicationAgreement:1`); the exact format is information-standard-specific and registered in the realisation catalogue. The segment rules and the registered prefixes are listed in the [appendix](#appendix-operation-token-format-details).
+Operations are the fine-grained interactie-ids that MAY appear in the request scope alongside the transaction identifier, to narrow the granted scopes for least-privilege. Each must name one of the operations that realise the scoped transaction (the AS verifies this at issuance), and omitting them requests all of the transaction's operations. The general shape is `<verb>:<artifact>:<version>` (e.g. `search:mp-MedicationAgreement:1`); the exact format is information-standard-specific and registered in the realisation catalogue. The segment rules and the registered prefixes are listed in the [appendix](#appendix-operation-identifier-format-details).
 
-#### Scope tokens are opaque identifiers
+#### Scope entries are opaque strings
 
-For the purpose of policy matching, both the transaction token and the operation tokens are treated as opaque strings: the AS looks them up in the trust framework's catalogue of registered transactions and operations, and matches against the policy by exact-string comparison. The format conventions are human-readable structure, not parsing requirements. Telling the two token kinds apart (REQ-1, REQ-3) needs only a shape check: the transaction token is dot-separated with a `tx` marker; operation tokens are colon-separated with a verb prefix.
+For the purpose of policy matching, both the transaction identifier and the operation identifiers are treated as opaque strings: the AS looks them up in the trust framework's catalogue of registered transactions and operations, and matches against the policy by exact-string comparison. The format conventions are human-readable structure, not parsing requirements. Telling the two kinds apart (REQ-1, REQ-3) needs only a shape check: the transaction identifier is dot-separated with a `tx` marker; operation identifiers are colon-separated with a verb prefix.
 
 #### Conformance: AT request
 
-> **REQ-1 (SHALL).** An AT request SHALL contain exactly one transaction scope token.
+> **REQ-1 (SHALL).** An AT request SHALL contain exactly one transaction identifier in its scope.
 >
-> **REQ-2 (SHALL).** The AS SHALL reject the request if REQ-1 is violated (zero or more than one token).
+> **REQ-2 (SHALL).** The AS SHALL reject the request if REQ-1 is violated (zero or more than one transaction identifier).
 >
-> **REQ-3 (MAY).** The request scope MAY contain operation tokens (interactie-ids), each one belonging to the scoped transaction's realisation, to narrow the minted scopes for least-privilege.
+> **REQ-3 (MAY).** The request scope MAY contain operation identifiers (interactie-ids), each one naming an operation that realises the scoped transaction, to narrow the granted scopes for least-privilege.
 >
-> **REQ-4 (SHALL).** The AS SHALL reject any operation token that does not belong to the scoped transaction's realisation.
+> **REQ-4 (SHALL).** The AS SHALL reject any operation identifier that does not name an operation realising the scoped transaction.
 
 #### Conformance: issued AT
 
-> **REQ-5 (SHALL).** The transaction scope token SHALL appear in the AT's `scope` alongside the minted SMART on FHIR scopes. The `scope` member is standard in both JWT access tokens and introspection responses, so the transaction identifier is visible to the resource server and the audit subsystem without any non-standard field.
->
-> **REQ-6 (MAY).** The AT MAY additionally carry the transaction token as a dedicated `tx` claim, for consumers that prefer not to parse `scope`; when present, its value SHALL equal the token in `scope`.
+> **REQ-5 (SHALL).** The transaction identifier SHALL appear in the AT's `scope` alongside the granted SMART on FHIR scopes. The `scope` member is standard in both JWT access tokens and introspection responses, so the transaction identifier is visible to the resource server and the audit subsystem without any non-standard field.
 
 #### Conformance: AS behaviour
 
-> **REQ-7 (SHALL).** The AS SHALL select the applicable PermissionMatrix entry by direct match of the transaction and the resolved AuthorizationRole, not by derivation from other tokens or context.
+> **REQ-6 (SHALL).** The AS SHALL select the applicable PermissionMatrix entry by direct match of the transaction and the resolved AuthorizationRole, not by derivation from other scope entries or context.
 >
-> **REQ-8 (SHALL).** For the scoped transaction, the AS SHALL verify that:
+> **REQ-7 (SHALL).** For the scoped transaction, the AS SHALL verify at issuance that:
 >
 > - the ServiceProvider's claims (its Qualification and the ServiceProvider delegation) resolve, via a SystemRolePrerequisite, to a QualifiedSystemRole whose coverage includes the scoped transaction;
 > - the presented identity claims resolve, via a RolePrerequisite, to an AuthorizationRole that the PermissionMatrix permits for the transaction;
-> - if the AuthorizationRole is exercised under mandate (defined as: the organisation acting unattended, or a user acting under the professional's responsibility), then (a) the PermissionMatrix entry SHALL be delegatable, and (b) a HealthcareProfessional-to-HealthcareOrganization delegation SHALL authorize the business role the AuthorizationRole refines;
-> - the context gate passes (consent, treatment relationship, purpose-of-use, where required).
+> - if the AuthorizationRole is exercised under mandate (defined as: the organisation acting unattended, or a user acting under the professional's responsibility), then (a) the PermissionMatrix entry SHALL be delegatable, and (b) a HealthcareProfessional-to-HealthcareOrganization delegation SHALL authorize the business role the AuthorizationRole refines.
 >
-> **REQ-9 (SHALL).** The AS SHALL reject the request if the transaction is unknown, no PermissionMatrix entry permits the resolved AuthorizationRole, or any check in REQ-8 fails.
+> **REQ-8 (SHALL).** The context checks of the scoped transaction's use case SHALL be enforced before data is released. The trust framework SHALL declare, per use case, the enforcement point of each check: the AS at token issuance, the AS at token introspection, or a policy decision point at the resource server. The AS SHALL evaluate the checks declared for issuance before issuing the AT.
+>
+> **REQ-9 (SHALL).** The AS SHALL reject the request if the transaction is unknown, no PermissionMatrix entry permits the resolved AuthorizationRole, any check in REQ-7 fails, or any context check declared for issuance fails.
 
 #### Identity claims, context, and verification
 
@@ -247,9 +251,9 @@ In current Dutch implementations these claims appear in several forms, sometimes
 
 Which claims a request must carry follows from the prerequisites: exactly those the scoped transaction's RolePrerequisite and SystemRolePrerequisite read to resolve the AuthorizationRole and the QualifiedSystemRole. There is no separate required-claims list to maintain.
 
-**Context gate.** Role resolution answers "who is the requester"; the context gate answers "is sharing this patient's data allowed". It evaluates ContextClaims about the request rather than the requester: the patient (BSN), the Enrollment (the treatment relationship), consent, and purpose-of-use. Purpose-of-use is the requester's declared purpose for the request; it is distinct from the legal basis (grondslag) that makes sharing lawful, although the declared purpose determines which legal basis must hold. The gate is attached to the use case because the claims it evaluates concern the intent, which all the use case's transactions share; attaching identical gates per transaction would only duplicate them. A trust framework MAY narrow the gate for an individual transaction, never loosen it. Because a transaction belongs to exactly one use case, the scoped transaction fixes which gate applies. The AS evaluates it alongside the PermissionMatrix (REQ-8).
+**Context checks.** Role resolution answers "who is the requester"; the context checks answer "is sharing this patient's data allowed". They evaluate ContextClaims about the request rather than the requester: the patient (BSN), the Enrollment (the treatment relationship), consent, and purpose-of-use. Purpose-of-use is the requester's declared purpose for the request; it is distinct from the legal basis (grondslag) that makes sharing lawful, although the declared purpose determines which legal basis must hold. The checks are attached to the use case because the claims they evaluate concern the intent, which all the use case's transactions share; attaching identical checks per transaction would only duplicate them. A trust framework MAY narrow the checks for an individual transaction, never loosen them. Because a transaction belongs to exactly one use case, the scoped transaction fixes which checks apply. Where each check is enforced is declared per use case (REQ-8); the design notes discuss that choice.
 
-> **REQ-10 (SHALL).** The client SHALL present the identity claims needed to resolve the AuthorizationRole and the QualifiedSystemRole for the scoped transaction, together with the ContextClaims the applicable context gate requires (the use case's gate, possibly narrowed for the scoped transaction). The AS SHALL verify role resolution, the matrix permission, and the context gate independently, and SHALL reject the request if any required claim is absent or any check fails.
+> **REQ-10 (SHALL).** The client SHALL present the identity claims needed to resolve the AuthorizationRole and the QualifiedSystemRole for the scoped transaction, together with the ContextClaims required by the context checks declared for issuance (the use case's checks, possibly narrowed for the scoped transaction). The AS SHALL verify role resolution, the matrix permission, and the issuance-declared context checks independently, and SHALL reject the request if any required claim is absent or any check fails.
 
 ### Adoption
 
@@ -265,7 +269,7 @@ The model claims no new governance body. Each construct already exists in every 
 | DVA/DVP admission (MedMij) _(draft mapping, to be verified)_ | Qualification plus Membership |
 {:.grid .table-hover}
 
-The minimal first step is the transaction scope token format alone: it requires no registry changes beyond listing the tokens, is visible on the wire, and gives audit and cross-framework tooling a uniform identifier. The full layer-2 publication can follow per framework, per information standard.
+The minimal first step is the transaction identifier format alone: it requires no registry changes beyond listing the identifiers, is visible on the wire, and gives audit and cross-framework tooling a uniform identifier. The full layer-2 publication can follow per framework, per information standard.
 
 Open issue: custodianship of the shared vocabulary (this chapter) once more than one framework adopts it. Candidates: Nictiz (owns layer 1), or the generieke functies programme. To be resolved with the trust framework architects.
 
@@ -275,7 +279,7 @@ Open issue: custodianship of the shared vocabulary (this chapter) once more than
 
 Happy path. Any check failure results in rejection, not shown for clarity. The legend on the diagram marks each step's input sources: **R** for the AT request, **L1** for the information-layer catalogue, **L2** for the trust-layer registry, **L3** for the realisation-layer catalogue (the interactietabel). Steps that depend on derived context (e.g. "the required system role per operation") inherit their source from the step that resolved that context.
 
-Because the AT is scoped to a single transaction, role resolution, the system-role coverage check, the matrix lookup, and the context gate are each evaluated once for that transaction; any operations in the request only narrow the minted scopes.
+Because the AT is scoped to a single transaction, role resolution, the system-role coverage check, the matrix lookup, and the issuance-declared context checks are each evaluated once for that transaction; any operations in the request only narrow the granted scopes.
 
 ### Design notes
 
@@ -285,11 +289,11 @@ _This section is rationale, not specification: it argues the design decisions th
 
 - The _transaction_ is the grain at which the PermissionMatrix decides: each cell maps `(AuthorizationRole, Transaction)` to allow or deny. Scoping the AT to one transaction aligns the wire with the decision: the AS reads the transaction, resolves the role, and looks up one cell.
 - The prerequisites are per transaction: which conditions must hold (the role resolution, the system-role coverage, the delegation, the context check) are set by the transaction. Bundling several transactions into one AT would mean satisfying the union of their prerequisites, which is awkward to express and can even conflict.
-- A _use case_ is too coarse for the AT scope: one AT would span many transactions with differing prerequisites, and an operation shared between them could not be attributed to a single cell. The use case is a catalogue grouping of transactions and the carrier of the context gate, not a key the matrix or the AT needs, and it does not appear on the wire.
-- An _operation_ is too fine: it is a wire-level interactie-id used for least-privilege scope minting, below the grain at which permission is decided. It is also reusable across transactions, so an operation alone does not identify the intent.
+- A _use case_ is too coarse for the AT scope: one AT would span many transactions with differing prerequisites, and an operation shared between them could not be attributed to a single cell. The use case is a catalogue grouping of transactions and the carrier of the context checks, not a key the matrix or the AT needs, and it does not appear on the wire.
+- An _operation_ is too fine: it is a wire-level interactie-id used for least-privilege scope granting, below the grain at which permission is decided. It is also reusable across transactions, so an operation alone does not identify the intent.
 - An AT covers one activity the requester performs (one transaction, e.g. `Raadplegen verstrekkingsverzoek`). A request that needs several transactions at once (a full medication overview for one patient) is served by an overview transaction such as Medicatieoverzicht, itself one transaction, or by issuing several ATs.
 
-This makes the wire chattier, and that cost is accepted deliberately. A viewer that opens the full Medicatiebouwstenen use case touches seven raadplegen transactions and therefore needs seven token requests, each a round trip to the source-side AS (the AS is usually co-located with the RS). Three things bound the cost. The requests are independent, so they can be issued in parallel. The issued AT is cacheable per (transaction, patient) within its lifetime, so the volume is per viewer session, not per screen refresh. Batching several transactions into one AT was considered and rejected. The prerequisites and the context gate are per transaction. A bundled AT must either satisfy every bundled transaction's conditions at once, which fails entirely when one gate fails (and gates can conflict: consent may cover one data category but not another), or be evaluated loosely at bundle level. Loose evaluation erodes the per-transaction granularity of consent and audit; it is exactly the implicit-scope pattern this proposal removes. How many ATs one wire exchange may mint is a layer-3 profiling choice (a framework can adopt a batching or token-exchange profile without touching the model), as long as each issued AT stays scoped to one transaction.
+This makes the wire chattier, and that cost is accepted deliberately. A viewer that opens the full Medicatiebouwstenen use case touches seven raadplegen transactions and therefore needs seven token requests, each a round trip to the source-side AS (the AS is usually co-located with the RS). Three things bound the cost. The requests are independent, so they can be issued in parallel. The issued AT is cacheable per (transaction, patient) within its lifetime, so the volume is per viewer session, not per screen refresh. Batching several transactions into one AT was considered and rejected. The prerequisites and the context checks are per transaction. A bundled AT must either satisfy every bundled transaction's conditions at once, which fails entirely when one check fails (and checks can conflict: consent may cover one data category but not another), or be evaluated loosely at bundle level. Loose evaluation erodes the per-transaction granularity of consent and audit; it is exactly the implicit-scope pattern this proposal removes. How many ATs one wire exchange may issue is a layer-3 profiling choice (a framework can adopt a batching or token-exchange profile without touching the model), as long as each issued AT stays scoped to one transaction.
 
 #### Why consent, treatment relationship, and purpose are layer-2 constructs
 
@@ -297,7 +301,7 @@ The layer-2 constructs can be derived from the transaction dataset itself. A tra
 
 {% include authorization-model-bridge.svg %}
 
-- **The patient identifier (BSN) is the data-subject join key.** It appears in the query parameters as a layer-1 concept, and layer 2 joins on it: the AS enforces that the BSN in the query equals the `patient` scope of the access token, and the context claims (consent, treatment relationship) are about that same patient. Whether a patient is involved is itself a layer-1 fact: if the transaction dataset carries no patient identifier, there is no data-subject, the `patient` attribute on the access token is absent, and the patient-bound context claims do not apply.
+- **The patient identifier (BSN) is the data-subject join key.** It appears in the query parameters as a layer-1 concept, and layer 2 joins on it: the AS enforces that the BSN in the query equals the `patient` attribute of the access token, and the context claims (consent, treatment relationship) are about that same patient. Whether a patient is involved is itself a layer-1 fact: if the transaction dataset carries no patient identifier, there is no data-subject, the `patient` attribute on the access token is absent, and the patient-bound context claims do not apply.
 - **Consent, treatment relationship, and purpose are absent from the dataset.** No dataset concept carries them. That confirms they are layer-2 constructs: ContextClaims evaluated by the trust framework, not data the transaction exchanges. The consent check is the source's responsibility, whether against a national facility (Mitz) or a local consent registration; it is not part of the requester-provided claim set, and the diagram marks it separately.
 
 Everything else in the query stays in layer 1: record-narrowing identifiers (a behandeling-id, a record-id) map to no layer-2 claim, and payload actor concepts (a record's prescriber) relate to the requester's identity claims in type only, never in instance.
@@ -310,9 +314,11 @@ _Where._ The governing principle: a fact must surface as a wire claim exactly wh
 
 - The source owns the decision to make data available (the beschikbaarstellen slice of the matrix). It enforces that itself, or a central intermediary enforces it on its behalf. The consumer is never the enforcer of source-side policy.
 - The professional-to-organisation delegation is internal to the source: a source enforcing its own policy already knows its employment relations and mandates, and presents no credentials to itself. The mandate becomes a wire credential only under intermediary enforcement, when the intermediary cannot see inside the organisation.
-- The ServiceProvider delegation is evaluated by the counterparty of the exchange, which can never observe that relationship directly. It therefore remains evidence in every topology, as a presented credential or a trusted registry entry. Where an organisation operates its own systems, the delegation degenerates into the organisation's own identity claim, but the evidence requirement stays.
+- The ServiceProvider delegation is evaluated by the counterparty of the exchange, which can never observe that relationship directly. It therefore remains evidence in every topology, as a presented credential or a trusted registry entry. Where an organisation operates its own systems, the delegation reduces to the organisation's own identity claim, but the evidence requirement stays.
 
 _When._ Evidence can bind at three moments: at ecosystem registration (the enforcer verified the fact when the member joined), at decision time from a registry (the AS consults a store of member claims when issuing the token), or presented with the message itself. The same layer-2 facts feed all three; the binding time should match the volatility of the fact. Qualifications change rarely, so registration-time verification suffices. Delegations change more often. The treatment relationship and consent are per-patient and per-moment, so they bind at decision time.
+
+_Which point for the context checks._ The context checks have no single right enforcement point: their inputs are per-patient and volatile, and where the evidence lives differs per deployment. The model therefore only requires that the trust framework declares the enforcement point of each check per use case (REQ-8): the AS at issuance, the AS at introspection time, or a policy decision point at the resource server. Introspection is worth singling out: there the resource server's runtime question is answered by the AS, so volatile facts can be re-evaluated on fresh data without the resource server holding any policy. Whatever the declared point, an undeclared check is a missing check; the declaration exists so that no party assumes the other one checked.
 
 The OAuth wire is asymmetric here: the request side has a claim-carrying convention (the AccessTokenRequest), the response side has none. A topology that wants a third party to verify source-side claims at response time therefore needs a wire convention that this proposal does not define. Verifying source-side claims at registration time or at token-issuance time avoids that gap, and fails before any data is assembled.
 
@@ -326,7 +332,7 @@ _This section is non-normative._ Each example shows the request scope, the AS de
 
 #### Worked example: a GP consults a patient's medication agreements
 
-**Use case** Medicatiebouwstenen, **transaction** Raadplegen medicatieafspraak. The request scope is one transaction token plus, optionally, the operations that narrow the minted scopes:
+**Use case** Medicatiebouwstenen, **transaction** Raadplegen medicatieafspraak. The request scope is one transaction identifier plus, optionally, the operation identifiers that narrow the granted scopes:
 
 ```
 aorta.tx.mp.medicatieafspraak-raadplegen.3-0-0
@@ -366,11 +372,11 @@ _`PermissionMatrix`_ (slice for this transaction), keyed on `(AuthorizationRole,
 
 The rolcode discriminator is what lets the matrix differ per rolcode set even within one business role: here a verpleegkundige is denied, and for the sibling transaction `Beschikbaarstellen medicatieafspraak` the Autorisatierichtlijn permits artsen but not apothekers.
 
-_Context gate (on the use case)._ Medicatiebouwstenen requires, for this patient, an Enrollment (treatment relationship) and a Mitz consent that permits sharing medication data. ContextClaims: `patient` (BSN), `Enrollment`, `mitzConsent`.
+_Context checks (on the use case)._ Medicatiebouwstenen requires, for this patient, an Enrollment (treatment relationship) and a Mitz consent that permits sharing medication data. ContextClaims: `patient` (BSN), `Enrollment`, `mitzConsent`. In this example both checks are declared for issuance (REQ-8).
 
-**AS decision.** A huisarts requests it, authenticated and in the loop (attended). Role resolution: `rolcode=01.015` is in the `MedicatieRaadplegerArts` set, so the role resolves to `MedicatieRaadplegerArts`; no delegation is involved. System-role pipeline: the Qualification and the ServiceProvider delegation both name `MedicatieafspraakRaadplegend`, so the QualifiedSystemRole resolves and covers the scoped transaction. Matrix: `(MedicatieRaadplegerArts, Raadplegen medicatieafspraak)` = allow, delegatable. Context gate: treatment relationship and Mitz consent pass. The AT is issued. Had the organisation's system made this request unattended (a background refresh, say), the role would only resolve with a HCP-to-HCO delegation naming `Medicatieraadpleger`, and only because the matrix cell says `delegatable = yes`.
+**AS decision.** A huisarts requests it, authenticated and in the loop (attended). Role resolution: `rolcode=01.015` is in the `MedicatieRaadplegerArts` set, so the role resolves to `MedicatieRaadplegerArts`; no delegation is involved. System-role pipeline: the Qualification and the ServiceProvider delegation both name `MedicatieafspraakRaadplegend`, so the QualifiedSystemRole resolves and covers the scoped transaction. Matrix: `(MedicatieRaadplegerArts, Raadplegen medicatieafspraak)` = allow, delegatable. Context checks: treatment relationship and Mitz consent pass. The AT is issued. Had the organisation's system made this request unattended (a background refresh, say), the role would only resolve with a HCP-to-HCO delegation naming `Medicatieraadpleger`, and only because the matrix cell says `delegatable = yes`.
 
-**Issued AT (introspection).** The operation mints the SMART scope (`mp-MedicationAgreement` maps to FHIR `MedicationRequest`):
+**Issued AT (introspection).** The AS grants the SMART on FHIR scope for the requested operation (`mp-MedicationAgreement` maps to FHIR `MedicationRequest`):
 
 ```json
 {
@@ -387,7 +393,7 @@ _Context gate (on the use case)._ Medicatiebouwstenen requires, for this patient
 
 #### Same dataset, different use case: a citizen via MedMij
 
-The same medicatieafspraak fetched through a citizen's PGO is a **different transaction**, because the use case and its context gate differ: the citizen authenticates with DigiD, the role resolves to the patient rather than a professional, and there is no treatment-relationship gate. Only the operation (`search:...MedicationAgreement...`) is shared, illustrating that operations are reusable realisation blocks while transactions are use-case-bound.
+The same medicatieafspraak fetched through a citizen's PGO is a **different transaction**, because the use case and its context checks differ: the citizen authenticates with DigiD, the role resolves to the patient rather than a professional, and there is no treatment-relationship check. Only the operation (`search:...MedicationAgreement...`) is shared, illustrating that operations are reusable realisation blocks while transactions are use-case-bound.
 
 ```
 medmij.tx.mp.medicatieafspraak-raadplegen.1-0
@@ -413,7 +419,7 @@ aorta.tx.mp.medicatievoorschrift-sturen.3-0-0
 transaction:mp-MedicationPrescriptionProcessing-Bundle:1
 ```
 
-Role resolution resolves `AuthorizationRole = VoorschrijverArts` (`rolcode=01.015`; the voorschrijver is the authenticated principal, so no delegation); the system-role pipeline passes on system role `VoorschriftSturend` (Qualification and ServiceProvider delegation both naming it, no refinement involved); the matrix permits `(VoorschrijverArts, Sturen medicatievoorschrift)`; the bundle operation mints write scopes.
+Role resolution resolves `AuthorizationRole = VoorschrijverArts` (`rolcode=01.015`; the voorschrijver is the authenticated principal, so no delegation); the system-role pipeline passes on system role `VoorschriftSturend` (Qualification and ServiceProvider delegation both naming it, no refinement involved); the matrix permits `(VoorschrijverArts, Sturen medicatievoorschrift)`; the AS grants write scopes for the bundle operation.
 
 ```json
 {
@@ -428,9 +434,9 @@ Role resolution resolves `AuthorizationRole = VoorschrijverArts` (`rolcode=01.01
 }
 ```
 
-### Appendix: operation token format details
+### Appendix: operation identifier format details
 
-The operation token format adopts the `interactionId` shape of the [AORTA-on-FHIR interactietabel](https://aorta-on-fhir.public.vzvz.nl/aorta-on-fhir-specificaties/Working-version/aorta-interactietabel). Two shapes exist:
+The operation identifier format adopts the `interactionId` shape of the [AORTA-on-FHIR interactietabel](https://aorta-on-fhir.public.vzvz.nl/aorta-on-fhir-specificaties/Working-version/aorta-interactietabel). Two shapes exist:
 
 ```
 <verb>:<artifact>:<version>                       AORTA-internal style
@@ -459,10 +465,10 @@ Segment rules:
   - `twiin-` for a Twiin infrastructure artifact (`twiin-TaskNotifiedPull`)
   - `aorta-` for an AORTA infrastructure artifact (`aorta-DataReference`)
   - The set is open-ended; new information standards may introduce their own prefix.
-- `<version>` is the version of the interactie definition itself, not of the zib or FHIR resource. Bare integer for AORTA-internal style (`1`, `2`); dotted decimal for MedMij-facing style (`1.0`). This matches the version format of the transaction token (numeric, no `v` prefix).
+- `<version>` is the version of the interactie definition itself, not of the zib or FHIR resource. Bare integer for AORTA-internal style (`1`, `2`); dotted decimal for MedMij-facing style (`1.0`). This matches the version format of the transaction identifier (numeric, no `v` prefix).
 - `<request|response>` (MedMij style only) marks the direction of the message in a paired exchange.
 
-The exact shape of the operation token is information-standard-specific: each information standard registers its own artifact prefixes and version conventions. New information standards are encouraged to follow the `<verb>:<artifact>:<version>` shape above for cross-framework consistency, but the proposal does not mandate it.
+The exact shape of the operation identifier is information-standard-specific: each information standard registers its own artifact prefixes and version conventions. New information standards are encouraged to follow the `<verb>:<artifact>:<version>` shape above for cross-framework consistency, but the proposal does not mandate it.
 
 ### Glossary
 
@@ -479,16 +485,17 @@ Translation table for the information-layer (L1) catalogue terms:
 | Qualification          | kwalificatie        |
 {:.grid .table-hover}
 
-- **AS**: Authorization Server, mints access tokens.
+- **AS**: Authorization Server, issues access tokens.
 - **AT**: Access Token.
-- **AccessTokenRequest**: the OAuth 2.0 request sent by the ServiceProvider to the AS, carrying the `tx` scope token, optional operations, asserted identity claims, and context claims.
+- **AccessTokenRequest**: the OAuth 2.0 request sent by the ServiceProvider to the AS, carrying the transaction identifier (`tx`), optional operation identifiers, asserted identity claims, and context claims.
 - **AuthorizationRole**: the subject the PermissionMatrix keys on; one business role refined by a set of identity claims (typically rolcodes), resolved from presented claims by a RolePrerequisite.
 - **Business role** (bedrijfsrol): the role a person plays in a transaction (Voorschrijver, Verstrekker, Toediener, ...). Unit of HealthcareProfessional-to-HealthcareOrganization delegation, and the role an AuthorizationRole refines.
 - **Dataset**: a tree of dataset concepts; either a primary dataset of an information standard or an imported building-block dataset (such as a zib).
 - **DatasetConcept**: one node of a dataset (a group or an item), carrying a baseline conformance and cardinality that a transaction may restrict.
 - **DEZI**: the successor programme to the UZI register for identifying healthcare professionals; it keeps the identifier and rolcode concepts. This chapter uses UZI/rolcode terminology.
 - **IdentityClaim**: a typed assertion about the requester that the policy evaluates. Carried in many wire formats (signed SAML claim, Verifiable Credential, JWT claim by a trusted AS, mTLS-derived claim, ...).
-- **ContextClaim**: a typed assertion about the request context rather than the requester (patient, Enrollment, consent, purpose-of-use), evaluated by the use case's context gate.
+- **Context check**: a per-use-case rule that evaluates ContextClaims; its enforcement point (AS at issuance, AS at introspection, or a policy decision point at the resource server) is declared per use case (REQ-8).
+- **ContextClaim**: a typed assertion about the request context rather than the requester (patient, Enrollment, consent, purpose-of-use), evaluated by the use case's context checks.
 - **Enrollment**: a ContextClaim for the patient's treatment relationship; the professional issues it to the organisation, attesting that they enrol or treat the patient.
 - **Information layer (L1)**: the layer of the information standards; the Nictiz catalogue of use cases, transactions, roles, and datasets.
 - **Information standard** (informatiestandaard): a healthcare information standard (e.g. Medicatieproces, BgZ), in the Netherlands mostly maintained by Nictiz.
@@ -500,18 +507,20 @@ Translation table for the information-layer (L1) catalogue terms:
 - **Purpose-of-use**: the requester's declared purpose for a request (treatment, emergency, ...), a ContextClaim. Distinct from the legal basis; the declared purpose determines which legal basis must hold.
 - **Qualification** (kwalificatie): the claim by which a ServiceProvider asserts that its product passed qualification for a given system role. The qualification itself is the upstream certification process.
 - **QualifiedSystemRole**: a layer 2 refinement of exactly one system role by transaction coverage, answering "which of the transactions using this system role does this qualification grant". Defaults to the system role itself, covering all its transactions. Resolved by a SystemRolePrerequisite.
-- **Realisation layer (L3)**: the layer that turns transactions into FHIR and OAuth artefacts: profiles, operations, scope tokens, access tokens.
+- **Realisation layer (L3)**: the layer that turns transactions into FHIR and OAuth artefacts: profiles, operations, scope identifiers, access tokens.
 - **RolePrerequisite**: a layer 2 rule that resolves a set of identity claims to an AuthorizationRole; a role may have several, and satisfying any one is enough.
 - **RS**: Resource Server, enforces SMART on FHIR scopes on FHIR endpoints.
 - **SoF scope**: SMART on FHIR v2 scope, e.g. `patient/MedicationRequest.s`.
+- **State rule**: a rule from the information standard's lifecycle restricting an operation to given data states and roles, listed in the realisation catalogue and enforced by the resource server while handling the request. Never carried on the access token.
 - **System role** (systeemrol): the role a system plays in a transaction (Sturend, Ontvangend, Raadplegend, Beschikbaarstellend). Unit of qualification and of ServiceProvider delegation.
 - **SystemRolePrerequisite**: a layer 2 rule that resolves a ServiceProvider's claims (notably its Qualification and delegation) to a QualifiedSystemRole; the system-role counterpart of a RolePrerequisite, with no matrix.
 - **Transaction** (transactie): a single interaction within a transaction group, e.g. `Raadplegen verstrekkingsverzoek` (the consumer queries a source) or `Beschikbaarstellen verstrekkingsverzoeken` (the source returns the requested data). The leaf functional unit of layer 1 and the unit the PermissionMatrix authorizes against; belongs to exactly one use case. Not to be confused with the FHIR transaction interaction (an atomic `Bundle` POST), which appears as a verb in operation tokens.
 - **Transaction group** (transactiegroep): a named group of related transactions, e.g. `Verstrekkingsverzoek (raadplegen/beschikbaarstellen)`.
 - **Transaction dataset** (transactiedataset): the subset of dataset concepts a transaction selects, each optionally restricted (conformance, cardinality, condition) relative to its baseline.
+- **Transaction identifier**: the identifier of the scoped transaction, carried in the OAuth `scope` of the AT request and the issued AT; format `<governance-body>.tx.<information-standard>.<transaction>.<version>`.
 - **Trust framework**: an independently governed set of agreements for data exchange (afsprakenstelsel).
 - **Trust layer (L2)**: the layer of the trust-framework constructs: role resolution, the permission matrix, qualifications, delegations, identity and context claims.
-- **Use case**: a sub-chapter of an information standard. A catalogue grouping of transaction groups; defines the intent and the context gate; not carried on the wire.
+- **Use case**: a sub-chapter of an information standard. A catalogue grouping of transaction groups; defines the intent and the context checks; not carried on the wire.
 - **Zib**: _zorginformatiebouwsteen_, a Dutch healthcare data model construct, published as a building-block dataset.
 
 ### References

--- a/input/pagecontent/authorization-model.md
+++ b/input/pagecontent/authorization-model.md
@@ -1,0 +1,422 @@
+<!--
+SPDX-FileCopyrightText: 2026 Steven van der Vegt
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+### Introduction
+
+Dutch healthcare data exchange runs under several authorization regimes (AORTA-on-FHIR, MedMij, Twiin, Nuts use-case communities). Each one has, over time, built its own internal authorization model: its own vocabulary for qualifications, its own delegation structures, its own scope-token grammar, its own way of pairing identity claims with policy. The models overlap conceptually, but never align. Cross-framework integration is therefore expensive and brittle.
+
+This chapter proposes a shared *authorization information model* and derives one concrete OAuth 2.0 wire convention from it. The model is layered: a layer 1 that adopts the Nictiz "Handleiding Wiki documentatie" structure verbatim, and a layer 2 that adds the authz-specific concepts that the Nictiz model does not address (qualifications, delegations, identity claims, the access token itself).
+
+The intended audience is architects of the trust frameworks listed above. The proposal is independent of how identity claims are attested. In current Dutch implementations identity claims appear in several forms, sometimes mixed within one request: signed claims in SAML tokens, Verifiable Credentials, JWT claims issued by a trusted Authorization Server, and claims derived from an mTLS client certificate. The proposal works with any of these; it does not prescribe a wire format.
+
+### Background
+
+#### Layered model
+
+Three layers are involved in defining how authorization works for Dutch healthcare data exchange:
+
+- **Layer 1, Information Standards (Nictiz)** defines *what* transactions exist. Owned by Nictiz via the [Handleiding Wiki documentatie](https://informatiestandaarden.nictiz.nl/wiki/Handleiding_Wiki_documentatie). Catalogues informatiestandaarden, use cases, transactiegroepen, transacties, systeemrollen, bedrijfsrollen, and the zibs they operate on. The same for all trust frameworks.
+- **Layer 2, Trust Framework** specifies *who* may perform *which* transactions, and under what conditions. Owned by the trust frameworks (VZVZ, MedMij, Twiin, Nuts working groups) and by this IG. Adds the governance constructs that gate access: authentication profiles, authorization policies, qualifications, the delegation chain, identity claims, and the actor model.
+- **Layer 3, OAuth wire** specifies *how* a single authorization decision surfaces in an OAuth 2.0 exchange. The access-token request, the issued access token, and the minted SMART on FHIR scopes that the resource server enforces.
+
+This chapter proposes a uniform model for layers 2 and 3. Layer 1 is taken as given.
+
+#### Layer 1: Information Standards (Nictiz)
+
+{% include authorization-model-nictiz.svg %}
+
+Hierarchy from outer to inner:
+
+- **Informatiestandaard**: top container (e.g. Medicatieproces 9). Owned by Nictiz.
+- **Use case**: a sub-chapter of an informatiestandaard, equal to a "scenario" in ART-DECOR. Coarse business framing.
+- **Transactiegroep**: a bundle of related transactions, e.g. `Medicatiegegevens (MGR/MGB)` for the pull variant or `Medicatievoorschrift (VOS/VOO)` for the push variant. The smallest unit that names a complete interaction.
+- **Transactie**: one direction of one exchange, e.g. `Raadplegen medicatiegegevens` or `Beschikbaarstellen medicatiegegevens`. FHIR or CDA profiles attach at this level.
+- **Operation** (interactie-id on the wire): a single wire-level operation within a transactie, identified as `<verb>:<artifact>:<version>` (e.g. `search:zib-MedicationAgreement:2`). One transactie has one or more operations; an artifact is a Zib or a FHIR Bundle profile.
+- **Systeemrol**: the role a system plays in a transactie. Four kinds: Sturend, Ontvangend, Raadplegend, Beschikbaarstellend. Unit of qualification.
+- **Bedrijfsrol**: the role a person plays in a transactie (Voorschrijver, Verstrekker, ...). Cross-cutting actor type.
+
+The **use case is the unit of authorization** in this proposal. A single user-facing data request often needs operations from more than one transactiegroep within the same use case. For example, the *Medicatiebouwstenen* use case in Medicatieproces 9 contains `Medicatiegebruik (raadplegen/beschikbaarstellen)` and `Medicatietoediening (raadplegen/beschikbaarstellen)` among others; a "show me everything about this patient's medication" view needs operations from both. Scoping the AT at the use-case level reflects that. The transactiegroep remains the unit of conformity (qualification, policy granularity per direction), but is not surfaced on the OAuth wire.
+
+#### Layer 2: Trust Framework
+
+{% include authorization-model-layer2.svg %}
+
+The Nictiz-layer entities `UseCase`, `Systeemrol`, and `Bedrijfsrol` appear in yellow because they are referenced from layer 1; they are not redefined here. Layer-2 entities are shown in blue.
+
+**Governance and policy:**
+
+- **TrustFramework**: an independently governed authorization regime (afsprakenstelsel). Owns the qualification programme, the identity-claim vocabulary, the authentication profiles, and the authorization policies used within its boundary.
+- **AuthenticationProfile** (the *presence* gate): defined per use case, lists the identity-claim *types* that must be present and valid on a request. Answers the question "is this request well-formed for the use case". For example, "any request for use case X must carry a rolcode claim, an organisation_id claim, a systeemrol claim, and an attest claim". Says nothing about which values of those claims are permitted. Shown in the diagram with `required_claim_types[]` as an attribute, rather than an explicit edge to `IdentityClaim`, to keep the diagram readable.
+- **AuthorizationPolicy** (the *permission* gate): defined per use case, specifies which combinations of identity-claim *values* are permitted for each operation in the use case. Answers the question "does this caller, with these specific claim values, have permission to perform this specific operation". For example, "rolcode `01.015` (Huisarts) is allowed to raadplegen MA, but not to beschikbaarstellen MA". Says nothing about which claim types must be present (that is the AuthenticationProfile's job). The AORTA realisation for medication is the *Autorisatierichtlijn medicatieveiligheid* published by VZVZ: a matrix mapping (rolcode, action, dataset) to ja/nee that the AS consults at mint time. Shown in the diagram with `allowed_combinations[]` as an attribute rather than explicit edges to `IdentityClaim` and `Operation`, for the same readability reason as `AuthenticationProfile`.
+
+The two are deliberately separated along the standard authentication-vs-authorization split. Presence and integrity is checked first via the AuthenticationProfile; permission given values is checked second via the AuthorizationPolicy. Mixing them into one entity is possible in implementation, but the conceptual gates remain distinct.
+
+**Actors:**
+
+- **HealthcareProfessional, HealthcareOrganization, ServiceProvider**: the three professional-side actor layers. The professional is employed by an organisation; the organisation is served by a service provider.
+- **Patient**: the data subject. In professional flows the patient is referenced via their BSN as the data-scope of the access token; the request principal is the ServiceProvider acting for the HealthcareProfessional and HealthcareOrganization. In *patient-channel (PHR) flows*, the patient becomes the asserting principal: they authenticate via DigiD with their PGO, and the PGO operator (a ServiceProvider qualified as a Dienstverlener Persoon under MedMij) makes the access-token request on their behalf. In both flows the `patient` attribute on the AccessTokenRequest carries the data-subject BSN; in PHR flows that BSN coincides with the authenticating principal's BSN.
+
+**Identity claims (asserted by the requester):**
+
+- **IdentityClaim** (abstract): a typed assertion about the requester that the policy evaluates. Generalises systeemrol, bedrijfsrol, rolcode, organisation identifiers, attest grounds, and similar. Each trust framework defines its own vocabulary. The Qualification and both delegations below are shown in the diagram as concrete subtypes of `IdentityClaim`.
+- **Qualification**: the certification that a vendor product (used by a service provider) may act in a given systeemrol. Issued by the trust framework. AORTA term: kwalificatie, recorded in TKID. MedMij splits this into DVA (provider-side) and DVP (PGO-side). Upstream of OAuth; the AS treats it as a precondition.
+- **HealthcareProfessional-to-HealthcareOrganization delegation**: the credential by which a healthcare professional grants their healthcare organisation authority to act on their professional responsibility, scoped to a set of bedrijfsrollen. The professional can only delegate what they ARE (a Voorschrijver, a Verstrekker, ...), so the delegation is at bedrijfsrol granularity.
+- **ServiceProvider delegation**: the credential by which a healthcare organisation grants a service provider authority to act for it on the wire, scoped to a set of systeemrollen. The healthcare organisation delegates technical capability.
+
+The delegation chain runs at two different layers: the HealthcareProfessional-to-HealthcareOrganization delegation operates at bedrijfsrol level, and the ServiceProvider delegation operates at systeemrol level. Each step delegates at the layer it can actually express. A healthcare professional is not a system; they cannot delegate a systeemrol.
+
+#### Layer 3: OAuth wire artefacts
+
+{% include authorization-model-layer3.svg %}
+
+Layer 1 entities (`UseCase`, `Operation`, `FHIRResource`) appear in yellow; layer 2 entities (`IdentityClaim`, `ServiceProvider`) appear in blue. Layer-3 entities are shown in green.
+
+- **AccessTokenRequest**: what the ServiceProvider sends to the AS. Carries one use-case scope token (the `uc`), the list of requested operations (interactie-ids), the asserted identity claims, and the patient context.
+- **AccessToken**: the OAuth 2.0 artefact returned on success. Authorizes exactly one use case, carries the verified identity claims, and carries the minted SMART on FHIR scopes.
+- **SoFScope**: a [SMART on FHIR v2](https://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html) scope (`<context>/<Resource>.<crud>`). The unit of resource-server enforcement, minted at issue time from the requested operations via the Zib and FHIRResource chain.
+
+Note the asymmetry between request and response: the **request carries interactie-ids**, the **response carries SMART on FHIR scopes**. The AS converts the former into the latter at mint time.
+
+An AT scoped to a use case can cover multiple transactiegroepen, each potentially using a different systeemrol. The AS verifies, per requested operation, that the matching systeemrol is qualified and delegated.
+
+#### Why use case is the scope unit
+
+- A *transactie* is too fine: a single direction (raadplegen without beschikbaarstellen) is meaningless on its own.
+- A *transactiegroep* is conceptually coherent but operationally inconvenient. Most real data requests span multiple transactiegroepen within one use case. Forcing one AT per transactiegroep multiplies round-trips and complicates correlation.
+- A *use case* matches how Nictiz organises related transacties and how data consumers think about a data request. Per-direction enforcement (systeemrol, bedrijfsrol, attest) still happens via the asserted identity claims and the operation-membership check at mint time.
+
+### Problem
+
+Each trust framework today carries its own authorization model. The models overlap conceptually but never align, which makes cross-framework integration disproportionately expensive. The same patterns appear in different vocabularies at different layers:
+
+- **Qualification**: TKID in AORTA, DVA/DVP in MedMij, similar mechanisms in Twiin. All express "this product may act in this technical role", but with different names, registries, and APIs.
+- **Delegation chain**: AORTA, MedMij, and Twiin each construct delegation chains between professionals, organisations, and service providers differently. The chain shape is usually similar; the credentials and granularities are not.
+- **Scope on the OAuth wire**: each framework has a different convention for how the authorized work is identified in a request and on the issued token.
+
+| Trust framework | What identifies the authorized work in the request scope | Survives onto issued AT? |
+|---|---|---|
+| AORTA professional (read) | implicit, derived from `(aorta.systeemrol.X, aorta.contextcode.Y)` | absent |
+| AORTA professional (write) | partially explicit, via `transaction:mp-X-Bundle:V` | partially preserved |
+| MedMij | explicit, tilde-attached `~medmij.gegevensdienst.<n>` | preserved |
+| Twiin | explicit, `twiin.gegevensdienst.<id>` | preserved |
+| Nuts use-case communities | varies per working group | varies |
+{:.grid .table-hover}
+
+Concrete consequences:
+
+1. **Implicit identification (AORTA read)**: the AS reconstructs intent from a pair of scope tokens. This is fragile to catalogue evolution and pushes semantic work into the AS.
+2. **Asymmetric AT contents**: MedMij carries the identifier on the issued AT, AORTA professional does not. Resource servers cannot uniformly audit by use case.
+3. **Inconsistent grammar across the wire**: verb-style, tilde-attached, category-style. Three vocabularies for the same semantic concept.
+4. **Composability is undefined**: what does a request with five interactie-ids mean? All required, any acceptable, an intersection? Each AS invents an answer.
+5. **Cross-framework reasoning is hard**: a developer writing a system that participates in two frameworks needs to learn two complete models and the unstated mapping between them.
+
+### Specification
+
+The Problem section above sets out what the convention has to address. The subsections below state the normative rules. Cumulatively, they require a shared layer-2 model, a uniform use-case identifier format on the OAuth wire, a single use case per request with the identifier preserved on the issued AT, and policy lookup by direct identifier match rather than derivation. The model is independent of how identity claims are attested.
+
+#### Authorization information model
+
+The normative model for layers 2 and 3 is the one shown in the Layer 2 and Layer 3 diagrams above. Implementations SHALL preserve the entity meanings as described in those subsections. Specifically:
+
+- A ServiceProvider's Qualifications SHALL be expressed per systeemrol.
+- A HealthcareProfessional-to-HealthcareOrganization delegation SHALL be expressed per bedrijfsrol.
+- A ServiceProvider delegation SHALL be expressed per systeemrol.
+- An AuthenticationProfile SHALL be defined per use case and SHALL enumerate the identity-claim types required for that use case.
+- An AccessTokenRequest SHALL reference exactly one UseCase and zero-or-more Operations.
+- An AccessToken SHALL authorize exactly one UseCase.
+
+Trust frameworks MAY use additional concepts beyond these (framework-specific governance entities, for example), but SHALL NOT redefine the meaning of the concepts above.
+
+#### Use-case scope token
+
+Every AT request defines exactly one use-case scope token with the format:
+
+```
+<governance-body>.uc.<information-standard>.<use-case>.<version>
+```
+
+Examples:
+
+```
+aorta.uc.mp.medicatiegegevens.3-0-0
+aorta.uc.mp.medicatievoorschrift.3-0-0
+aorta.uc.bgz.bgz.1-0
+medmij.uc.medicatie.actueel.1-0
+nuts.uc.eoverdracht.notifying.1-0
+```
+
+Segment rules:
+
+- `<governance-body>`: the body governing the namespace (`aorta`, `medmij`, `twiin`, `nuts`, ...).
+- `uc`: literal marker, identifying the token as a use-case scope token.
+- `<information-standard>`: the informatiestandaard slug within the governance body (`mp` for Medicatieproces, `bgz`, `eoverdracht`, ...).
+- `<use-case>`: kebab-case use-case identifier within the information standard.
+- `<version>`: hyphen-separated semantic version (`3-0-0`), or a single integer for major-only versioning (`3`). No `v` prefix, to match the operation token format below.
+
+#### Operation token format
+
+Operations are the fine-grained interactie-ids that appear in the request scope alongside the use-case token. The format is defined by the [AORTA-on-FHIR interactietabel](https://aorta-on-fhir.public.vzvz.nl/aorta-on-fhir-specificaties/Working-version/aorta-interactietabel). Two shapes exist:
+
+```
+<verb>:<artifact>:<version>                       AORTA-internal style
+<verb>:<artifact>:<version>:<request|response>    MedMij / PHR-facing style (PHR = Personal Health Record, the citizen-side PGO)
+```
+
+Examples (taken from the AORTA interactietabel for Medicatieproces 9):
+
+```
+search:mp-MedicationAgreement:1
+search:mp-MedicationDispense:1
+search:mp-AdministrationAgreement:1
+search:mp-MedicationUse2:1
+create:mp-MedicationAgreement:1
+transaction:mp-MedicationPrescriptionProcessing-Bundle:1
+search:MedicationStatement:1.0:request
+```
+
+Segment rules:
+
+- `<verb>` is one of the FHIR interaction types from the closed set: `create`, `read`, `update`, `delete`, `search`, `batch`, `transaction`, `operation`. The verb determines the wire semantics: `transaction` is a FHIR `Bundle` POST with `type=transaction`, `batch` is the looser-consistency sibling, `search` is FHIR search, and so on.
+- `<artifact>` identifies the target. It is either a bare FHIR resource type (PHR/MedMij interactions, e.g. `MedicationStatement`) or a profile name with a programme prefix. Prefixes seen in the AORTA interactietabel:
+  - `zib-` for a Zorginformatiebouwsteen profile (`zib-MedicationAgreement`, `zib-LivingSituation`)
+  - `mp-` for a Medicatieproces v9 artifact (`mp-MedicationDispense`, `mp-MedicationPrescriptionProcessing-Bundle`)
+  - `mp612-` for a Medicatieproces v6.12 conversion artifact
+  - `twiin-` for a Twiin infrastructure artifact (`twiin-TaskNotifiedPull`)
+  - `aorta-` for an AORTA infrastructure artifact (`aorta-DataReference`)
+  - The set is open-ended; new informatiestandaarden may introduce their own prefix.
+- `<version>` is the version of the interactie definition itself, not of the zib or FHIR resource. Bare integer for AORTA-internal style (`1`, `2`); dotted decimal for MedMij-facing style (`1.0`). This matches the version format of the use-case token (numeric, no `v` prefix).
+- `<request|response>` (MedMij style only) marks the direction of the message in a paired exchange.
+
+Each operation in a request scope must belong to a transactiegroep within the scoped use case. The AS verifies this at mint time.
+
+The exact shape of the operation token is information-standard-specific: each informatiestandaard registers its own artifact prefixes and version conventions. New information standards are encouraged to follow the `<verb>:<artifact>:<version>` shape above for cross-framework consistency, but the proposal does not mandate it.
+
+#### Scope tokens are opaque identifiers
+
+For the purpose of policy matching, both the use-case token and the operation tokens are treated as opaque strings: the AS looks them up in the trust framework's catalogue of registered use cases and operations, and matches against the policy by exact-string comparison. The format conventions above are human-readable structure, not parsing requirements.
+
+The two formats are deliberately distinguishable at a glance (the use-case token uses dot-separation with an explicit `uc` marker; operation tokens use colon-separation with a verb prefix). An AS implementation needs to identify which tokens in a request scope are which (per REQ-1 and REQ-3), but a simple shape check is sufficient; no internal-format parsing is required for policy evaluation.
+
+#### Conformance: AT request
+
+> **REQ-1 (SHALL).** An AT request SHALL contain exactly one use-case scope token.
+>
+> **REQ-2 (SHALL).** The AS SHALL reject the request if REQ-1 is violated (zero or more than one token).
+>
+> **REQ-3 (MAY).** The request scope MAY contain additional scope tokens (fine-grained operation requests as interactie-ids, channel tags), to be evaluated against the use case's allowed set.
+>
+> **REQ-4 (SHOULD).** Clients SHOULD include only the operation tokens they actually intend to use (least-privilege).
+
+#### Conformance: issued AT
+
+> **REQ-5 (SHALL).** The issued AT SHALL carry the use-case identifier as a `uc` claim, whose value equals the request's use-case scope token.
+>
+> **REQ-6 (SHALL).** The use-case scope token SHALL also appear in the AT's `scope` claim alongside the minted SMART on FHIR scopes.
+
+#### Conformance: AS behaviour
+
+> **REQ-7 (SHALL).** The AS SHALL select the applicable policy by direct lookup of the use-case identifier, not by derivation from other tokens or context.
+>
+> **REQ-8 (SHALL).** For every requested operation, the AS SHALL verify that:
+>
+> - the operation belongs to a transactiegroep within the scoped use case;
+> - the matching systeemrol is qualified for the ServiceProvider and authorized by the ServiceProvider delegation;
+> - the corresponding bedrijfsrol is authorized by the HealthcareProfessional-to-HealthcareOrganization delegation issued by the asserting healthcare professional;
+> - the asserted rolcode is permitted to perform the operation per the use case's AuthorizationPolicy.
+>
+> **REQ-9 (SHALL).** The AS SHALL reject requests whose use-case identifier maps to no known policy.
+
+#### Identity claims and verification
+
+Identity claims are the typed assertions the AS evaluates. The set asserted on a single request typically includes:
+
+- The professional's identifier (UZI) and rolcode.
+- The organisation's identifier (URA) and role type.
+- The systeemrol (or systeemrollen, if the request spans multiple transactiegroepen).
+- The bedrijfsrol (or bedrijfsrollen) the asserting professional is acting under.
+- The relevant attest grounds (treatment relationship, consent, ...).
+- The ServiceProvider's Qualification.
+- The two delegation credentials in the chain.
+
+In current Dutch implementations these claims appear in several forms, sometimes mixed within one request: signed claims in SAML tokens, Verifiable Credentials, JWT claims issued by a trusted Authorization Server, or claims derived from an mTLS client certificate. The proposal works with any of these; it does not prescribe a wire format.
+
+The use case's AuthenticationProfile lists which identity-claim types must be present. The AS checks the asserted claims against that list at request time. The further per-operation verifications (systeemrol, qualification, delegations, rolcode permission) are specified in REQ-8 under the AS behaviour conformance subsection.
+
+**Multi-systeemrol and multi-bedrijfsrol requests.** A single AT request can cover multiple transactiegroepen within the use case, each potentially requiring a different systeemrol or bedrijfsrol. The convention is that the client presents all relevant role claims up front, and the AS resolves the appropriate role per operation. Concretely:
+
+> **REQ-10 (SHALL).** The client SHALL present, as asserted identity claims on the request, all systeemrollen and all bedrijfsrollen that may apply to any of the requested operations within the use case. The AS SHALL resolve, per operation, which asserted systeemrol matches the operation's initiating systeemrol and which asserted bedrijfsrol applies; it SHALL verify each independently against the relevant Qualification, ServiceProvider delegation, and HealthcareProfessional-to-HealthcareOrganization delegation.
+
+A delegation at one systeemrol does not imply any other systeemrol; the same holds for bedrijfsrollen. The AS reasons over the asserted set as a whole, but each per-operation check is independent.
+
+### Evaluation flow
+
+{% include authorization-model-evaluation.svg %}
+
+Happy path. Any check failure results in rejection, not shown for clarity. The legend on the diagram marks each step's input sources: **R** for the AT request, **L1** for the Nictiz catalogue (layer 1), **L2** for the trust framework registry (layer 2). Steps that depend on derived context (e.g. "the required systeemrol per operation") inherit their source from the step that resolved that context.
+
+When the AT request spans multiple transactiegroepen within the use case, the qualification and the two delegation checks happen per operation: each operation may require a different systeemrol or bedrijfsrol.
+
+### Examples
+
+*This section is non-normative.* Each example shows the request scope, the AS decision summary, and the token introspection response ([RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662)) that the resource server or audit subsystem would receive for the issued AT. The introspection responses are illustrative and do not specify a wire format; specific identifier values are placeholders. Trust-anchored identity claims are shown abstractly; how they are proven is out of scope.
+
+#### MedMij: PGO fetches medication data
+
+Request scope:
+
+```
+medmij.uc.medicatie.actueel.1-0
+search:MedicationRequest:1.0:request
+search:MedicationStatement:1.0:request
+```
+
+Asserted identity claims: `subject_id` (citizen via DigiD).
+
+AS decision: the use case exists, both operations belong to transactiegroepen within it, the asserted claims satisfy the policy.
+
+Token introspection response:
+
+```json
+{
+  "active": true,
+  "uc": "medmij.uc.medicatie.actueel.1-0",
+  "scope": "medmij.uc.medicatie.actueel.1-0 patient/MedicationRequest.s patient/MedicationStatement.s",
+  "client_id": "...pgo-app...",
+  "sub": "bsn:999999990",
+  "patient": "bsn:999999990",
+  "token_type": "Bearer",
+  "exp": 1760000000,
+  "iat": 1759999100
+}
+```
+
+#### AORTA professional pull: GP queries medication overview
+
+A GP queries the medication overview of a specific patient. The request spans operations from multiple transactiegroepen within the `medicatiegegevens` use case.
+
+Request scope:
+
+```
+aorta.uc.mp.medicatiegegevens.3-0-0
+search:mp-MedicationAgreement:1
+search:mp-MedicationDispense:1
+search:mp-AdministrationAgreement:1
+search:mp-MedicationUse2:1
+```
+
+Asserted identity claims:
+
+- `subject_id` (behandelaar UZI)
+- `rolcode=Huisarts`
+- `organisation_id` (URA)
+- `organisation_role=Huisarts`
+- `systeemrol=MedicatieGegevensRaadplegend`
+- `bedrijfsrol=Medicatieraadpleger`
+
+AS decision: the use case exists; for each requested operation, the asserted `MedicatieGegevensRaadplegend` is the initiating systeemrol of the matching transactie; the ServiceProvider's Qualification covers that systeemrol; the ServiceProvider delegation authorizes it; the HealthcareProfessional-to-HealthcareOrganization delegation issued by the GP to their organisation authorizes the required `Medicatieraadpleger` bedrijfsrol.
+
+Token introspection response:
+
+```json
+{
+  "active": true,
+  "uc": "aorta.uc.mp.medicatiegegevens.3-0-0",
+  "scope": "aorta.uc.mp.medicatiegegevens.3-0-0 patient/MedicationRequest.s patient/MedicationDispense.s patient/MedicationStatement.s",
+  "client_id": "...gp-ehr...",
+  "sub": "uzi:00000123",
+  "patient": "bsn:999999990",
+  "token_type": "Bearer",
+  "exp": 1760000000,
+  "iat": 1759999100
+}
+```
+
+#### AORTA professional push: voorschrijver sends prescription
+
+Request scope:
+
+```
+aorta.uc.mp.medicatievoorschrift.3-0-0
+transaction:mp-MedicationPrescriptionProcessing-Bundle:1
+```
+
+Asserted identity claims:
+
+- `subject_id` (behandelaar UZI)
+- `rolcode=Huisarts`
+- `organisation_id` (URA)
+- `organisation_role=Huisarts`
+- `systeemrol=VoorschriftSturend`
+- `bedrijfsrol=Voorschrijver`
+
+AS decision: the use case exists; the bundle operation belongs to the `medicatievoorschrift` use case via its transactiegroep; the asserted `VoorschriftSturend` is the initiating systeemrol; the ServiceProvider is qualified and delegated for that systeemrol; the HealthcareProfessional-to-HealthcareOrganization delegation authorizes the `Voorschrijver` bedrijfsrol.
+
+Token introspection response:
+
+```json
+{
+  "active": true,
+  "uc": "aorta.uc.mp.medicatievoorschrift.3-0-0",
+  "scope": "aorta.uc.mp.medicatievoorschrift.3-0-0 patient/MedicationRequest.cu patient/MedicationRequest.s",
+  "client_id": "...gp-ehr...",
+  "sub": "uzi:00000123",
+  "patient": "bsn:999999990",
+  "token_type": "Bearer",
+  "exp": 1760000000,
+  "iat": 1759999100
+}
+```
+
+### Glossary
+
+- **AS**: Authorization Server, mints access tokens.
+- **AT**: Access Token.
+- **AccessTokenRequest**: the OAuth 2.0 request sent by the ServiceProvider to the AS, carrying the `uc` scope token, requested operations, asserted identity claims, and patient context.
+- **AuthenticationProfile**: a layer 2 entity defined per use case that enumerates the identity-claim types the use case requires. Checked at request time against the asserted claims.
+- **AuthorizationPolicy**: a layer 2 entity defined per use case that lists which combinations of identity-claim values (typically rolcode) are permitted for which operations. The AORTA realisation for medication is the *Autorisatierichtlijn medicatieveiligheid*.
+- **Bedrijfsrol**: the role a person plays in a transactie (Voorschrijver, Verstrekker, Toediener, ...). Unit of HealthcareProfessional-to-HealthcareOrganization delegation in this proposal.
+- **IdentityClaim**: a typed assertion about the requester that the policy evaluates. Carried in many wire formats (signed SAML claim, Verifiable Credential, JWT claim by a trusted AS, mTLS-derived claim, ...).
+- **Informatiestandaard**: a Nictiz healthcare information standard (e.g. Medicatieproces, BgZ).
+- **Kwalificatie**: qualification, the upstream certification that a vendor product may act as a given systeemrol.
+- **PDP**: Policy Decision Point, see [Authorization](authorization.html).
+- **RS**: Resource Server, enforces SMART on FHIR scopes on FHIR endpoints.
+- **SoF scope**: SMART on FHIR v2 scope, e.g. `patient/MedicationRequest.s`.
+- **Systeemrol**: the role a system plays in a transactie (Sturend, Ontvangend, Raadplegend, Beschikbaarstellend). Unit of qualification and of ServiceProvider delegation.
+- **Transactie**: one direction of one exchange within a transactiegroep.
+- **Transactiegroep**: a bundle of related transactions that together form a complete interaction. Unit of conformity but not surfaced on the OAuth wire by this proposal.
+- **Trust framework**: an independently governed authorization regime (afsprakenstelsel).
+- **Use case**: a sub-chapter of an informatiestandaard, equal to a "scenario" in ART-DECOR. The unit of authorization in this proposal.
+- **Zib**: *zorginformatiebouwsteen*, a Dutch healthcare data model construct.
+
+### References
+
+**Nictiz**
+
+- [Nictiz Handleiding Wiki documentatie](https://informatiestandaarden.nictiz.nl/wiki/Handleiding_Wiki_documentatie)
+- [ART-DECOR Medicatieproces scenarios](https://decor.nictiz.nl/pub/medicatieproces/)
+
+**AORTA (VZVZ)**
+
+- [AORTA-on-FHIR specificaties](https://aorta-on-fhir.public.vzvz.nl/aorta-on-fhir-specificaties/)
+- [AORTA-on-FHIR Interactietabel (Working version)](https://aorta-on-fhir.public.vzvz.nl/aorta-on-fhir-specificaties/Working-version/aorta-interactietabel)
+- [AORTA-on-FHIR Interfaces, common (v20250723)](https://aorta-on-fhir.public.vzvz.nl/aorta-on-fhir-specificaties/v20250723/interfaces-common)
+- [AORTA-on-FHIR Interfaces, autorisatie-server MedMij (v20250328)](https://aorta-on-fhir.public.vzvz.nl/aorta-on-fhir-specificaties/v20250328/interfaces-autorisatie-server-medmij)
+- [Autorisatierichtlijn medicatieveiligheid (AORTA-LSP)](https://www.aorta-lsp.nl/over-aorta-lsp/autorisatierichtlijnen/autorisatierichtlijn-medicatieveiligheid)
+
+**MedMij**
+
+- [MedMij afsprakenstelsel](https://afsprakenstelsel.medmij.nl/)
+
+**Twiin**
+
+- [Twiin afsprakenstelsel](https://twiin.nl/)
+
+**Standards and conventions**
+
+- [SMART on FHIR v2 scopes and launch context](https://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html)
+- [RFC 6749 - The OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749)
+- [RFC 7662 - OAuth 2.0 Token Introspection](https://datatracker.ietf.org/doc/html/rfc7662)
+- [RFC 2119 - Key words for use in RFCs to Indicate Requirement Levels](https://datatracker.ietf.org/doc/html/rfc2119)

--- a/input/pagecontent/authorization-model.md
+++ b/input/pagecontent/authorization-model.md
@@ -37,7 +37,7 @@ This proposal models authorization in three layers. The layering is a modelling 
 
 - **Layer 1, Information Standards** (the _information layer_) defines _what_ transactions exist and _what data_ they carry. In the Netherlands most information standards are maintained by Nictiz; this proposal adopts the Nictiz meta-model, per the [Handleiding Wiki documentatie](https://informatiestandaarden.nictiz.nl/wiki/Handleiding_Wiki_documentatie), as the layer-1 vocabulary. It catalogues information standards, use cases, transaction groups, transactions, system roles, business roles, and the datasets they operate on. The data definitions (datasets, zibs) are part of this layer; there is no separate data layer. This layer is the same for all trust frameworks.
 - **Layer 2, Trust Framework** (the _trust layer_) specifies _who_ may perform _which_ transactions, and under what conditions: role resolution, the permission matrix, qualifications, the delegation chain, identity claims, context claims. Today these constructs are filled per framework (VZVZ, MedMij, Twiin, Nuts-toepassingen). The model does not tie them to per-framework governance: with a shared vocabulary, layer-2 policies can be lifted to national governance where that is wanted.
-- **Layer 3, Realisation** (the _realisation layer_) specifies _how_ a transaction reaches the wire: the FHIR profiles that represent its data, the wire-level operations that carry it, and how a single authorization decision surfaces in an OAuth 2.0 exchange. The wire artefacts are the access-token request, the issued access token, and the granted scopes that the resource server enforces. This proposal realises the granted scopes as SMART on FHIR v2 scopes; the model does not depend on that choice.
+- **Layer 3, Realisation** (the _realisation layer_) specifies _how_ a transaction reaches the wire: the FHIR profiles that represent its data, the operations performed on those profiles, and how a single authorization decision surfaces in an OAuth 2.0 exchange. The wire artefacts are the access-token request, the issued access token, and the granted scopes that the resource server enforces. This proposal realises the granted scopes as SMART on FHIR v2 scopes; the model does not depend on that choice.
 
 This proposal defines a uniform model for layers 2 and 3. Layer 1 is taken as given.
 
@@ -58,7 +58,7 @@ Hierarchy from outer to inner:
 Three structural points matter for authorization:
 
 - **Containment, not reuse.** A transaction group belongs to one use case, and a transaction to one transaction group, so a transaction belongs to exactly one use case. Reuse across standards happens at the dataset, template, and value-set level, not at the transaction level. Fetching the same data under a different use case is, by definition, a different transaction, because the use case carries the intent and therefore the conditions.
-- **There is no operation concept in layer 1.** The functional model stops at the transaction. The fine-grained wire-level operations are realisation constructs and are introduced in layer 3.
+- **There is no operation concept in layer 1.** The functional model stops at the transaction. Operations belong to the realisation and are introduced in layer 3.
 - **Lifecycle rules are layer-1 facts.** Where an information standard defines a lifecycle for its data (status values and the permitted transitions), that state machine belongs to this layer. It surfaces in authorization as state rules on layer-3 operations, enforced by the resource server at request time; layer 3 works out why such rules never ride the access token.
 
 The transaction dataset itself shows what belongs in layer 2; the design notes contain that derivation.
@@ -123,11 +123,11 @@ The same machinery covers the citizen. The patient is an actor whose RolePrerequ
 
 ##### Enforcement topology
 
-The model defines policy as facts and rules: claims, prerequisites, the matrix, the context checks. Where those rules are enforced, and how the evidence reaches the enforcer, is a deployment choice the model constrains but does not fix. Two principles govern that choice. First, a granted scope is a decision, not a forwarded claim: by granting the transaction in the AT's scope, the AS asserts that the authorization decision was made. The holder of an issued AT can expect it to be accepted as-is at runtime; the resource server may still refuse the request itself, but only on checks whose inputs did not exist at issuance, such as state rules. Second, a fact must surface as a wire claim exactly when the evaluating party cannot observe it directly. The first principle splits the checks by input availability: the identity and permission checks bind at issuance (REQ-7), each context check's enforcement point is declared per use case (REQ-8), and state rules always evaluate at the resource server. The consequences (why the two delegations behave differently, when evidence should bind, what the OAuth wire can and cannot carry) are worked out in the design notes, after the evaluation flow.
+The model defines policy as facts and rules: claims, prerequisites, the matrix, the context checks. Where those rules are enforced, and how the evidence reaches the enforcer, is a deployment choice the model constrains but does not fix. Two principles govern that choice. First, a granted scope is a decision, not a forwarded claim: by granting the transaction in the AT's scope, the AS asserts that the authorization decision was made. The holder of an issued AT can expect it to be accepted as-is at runtime; the resource server may still refuse the request itself, but only on checks whose inputs did not exist at issuance, such as state rules. Second, a fact must surface as a wire claim exactly when the evaluating party cannot observe it directly. The first principle splits the checks by input availability: the identity and permission checks bind at issuance (REQ-5), each context check's enforcement point is declared per use case (REQ-6), and state rules always evaluate at the resource server. The consequences (why the two delegations behave differently, when evidence should bind, what the OAuth wire can and cannot carry) are worked out in the design notes, after the evaluation flow.
 
 #### Layer 3: Realisation
 
-The realisation layer (L3) turns the transaction into FHIR and OAuth artefacts. Its first construct is the **Operation**: a single wire-level interaction, identified as `<verb>:<artifact>:<version>` (e.g. `search:mp-MedicationAgreement:1`). Operations are reusable building blocks: the same operation can realise transactions in different use cases. One transaction is realised by one or more operations, and each operation targets one FHIR resource type, from which the granted scopes derive. The construct is not new: the [AORTA-on-FHIR interactietabel](https://aorta-on-fhir.public.vzvz.nl/aorta-on-fhir-specificaties/Working-version/aorta-interactietabel) defines the same thing as its `interactionId`, including the reuse across use cases (one operation row carrying a list of context codes); this proposal adopts that shape.
+The realisation layer (L3) turns the transaction into FHIR and OAuth artefacts. The realisation has two halves. The transaction's data maps onto FHIR profiles: for zib payloads, the published zib-to-FHIR profiles. The exchange itself maps onto **Operations**: the FHIR interactions (search, create, a `Bundle` POST, ...) performed on those profiles. One transaction is realised by one or more operations; the same operation can realise transactions in different use cases; each operation targets one FHIR resource type, from which the granted scopes derive. The construct is not new: the [AORTA-on-FHIR interactietabel](https://aorta-on-fhir.public.vzvz.nl/aorta-on-fhir-specificaties/Working-version/aorta-interactietabel) catalogues exactly this as its `interactionId` rows (e.g. `search:mp-MedicationAgreement:1`), including the reuse across use cases (one row carrying a list of context codes); this proposal adopts that shape for the realisation catalogue.
 
 Some rules can only be evaluated while handling the request, because they read the current state of the data. The Task workflow of a notified-pull exchange is the clearest example: whether the receiver may set a Task to `accepted` depends on the status the Task has now. This proposal calls these _state rules_ and defines them on layer 1, in plain text: the information standard states, per transaction, which role may perform which operation in which data state. For the eOverdracht Task: "the receiving organisation may move a Task from `requested` to `accepted` or `rejected`; it may not move a Task in any other state." The Nictiz meta-model has no formal construct for this today; plain text on the transaction suffices until it does. The realisation catalogue lists the state rules next to the operations they constrain, and the resource server enforces them while handling the request. How a resource server implements the check is out of scope: it depends on its technical stack. The access token never carries state rules, because the state they read does not exist at issuance. _(Draft: the eOverdracht wording above is illustrative; to be verified against the eOverdracht and Twiin realisations.)_
 
@@ -135,17 +135,17 @@ Some rules can only be evaluated while handling the request, because they read t
 
 The information-layer entity (`Transaction`) appears in yellow; trust-layer entities (`IdentityClaim`, `ServiceProvider`) in blue; realisation-layer entities, including the `Operation` and `FHIRResource`, in green.
 
-- **AccessTokenRequest**: what the ServiceProvider sends to the AS. Its `scope` parameter carries exactly one transaction identifier (the `tx`) and, optionally, operation identifiers (interactie-ids) that narrow the granted scopes. The request further carries the asserted identity claims and the context claims. The `patient` attribute carries the data-subject BSN where the transaction concerns a patient; the AS binds it at issuance, and the resource server (or a policy decision point in front of it) enforces that the patient identifier in the query equals the issued AT's `patient` attribute.
+- **AccessTokenRequest**: what the ServiceProvider sends to the AS. Its `scope` parameter carries exactly one transaction identifier (the `tx`). The request further carries the asserted identity claims and the context claims. The `patient` attribute carries the data-subject BSN where the transaction concerns a patient; the AS binds it at issuance, and the resource server (or a policy decision point in front of it) enforces that the patient identifier in the query equals the issued AT's `patient` attribute.
 - **AccessToken**: the OAuth 2.0 artefact returned on success. Authorizes exactly one transaction, carries the verified identity claims, and carries the granted SMART on FHIR scopes.
-- **SoFScope**: a [SMART on FHIR v2](https://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html) scope (`<context>/<Resource>.<crud>`). The unit of resource-server enforcement, granted at issuance from the requested operations via the profile and FHIR resource type. A scope may carry additional search parameters (e.g. `patient/Observation.rs?category=...`) where the operation-to-scope mapping defines them.
+- **SoFScope**: a [SMART on FHIR v2](https://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html) scope (`<context>/<Resource>.<crud>`). The unit of resource-server enforcement, granted at issuance from the transaction's operations via the profile and FHIR resource type. A scope may carry additional search parameters (e.g. `patient/Observation.rs?category=...`) where the operation-to-scope mapping defines them.
 
-Note the asymmetry between request and response: the **request carries the transaction identifier** (optionally narrowed by interactie-ids), the **response carries the transaction identifier plus the granted SMART on FHIR scopes**. The AS converts requested operations into scopes when it issues the AT.
+The request and the response deliberately speak different vocabularies. The **request carries the transaction identifier**: the intent, in information-standard terms. The **response carries the transaction identifier plus the granted SMART on FHIR scopes**: the enforcement artefacts of the FHIR realisation. The AS is the only party that translates between the two, converting the transaction's operations into scopes at issuance; the design notes argue why the request carries no operation identifiers.
 
-An AT is scoped to one transaction. The AS verifies that a resolved QualifiedSystemRole (backed by the Qualification and the ServiceProvider delegation) covers the transaction. Operations in the request only narrow the granted scopes. Why the transaction, and not the use case or the operation, is the scope unit is argued in the design notes.
+An AT is scoped to one transaction. The AS verifies that a resolved QualifiedSystemRole (backed by the Qualification and the ServiceProvider delegation) covers the transaction. Why the transaction, and not the use case or the operation, is the scope unit is argued in the design notes.
 
 Three mappings make this work, all living in a realisation catalogue published alongside the trust framework's registry:
 
-- transaction to operations: which operations realise which transaction. The AS uses it to validate requested operations (REQ-4).
+- transaction to operations: which operations realise which transaction. The AS uses it, together with the operation-to-scope mapping, to derive the granted scopes.
 - operation to scope: operation to profile to FHIR resource type to SMART on FHIR scope. The AS uses it when granting scopes.
 - operation to state rules: the plain-text state rules from the information standard, listed next to the operations they constrain. The resource server uses them while handling the request; the AS does not.
 
@@ -157,7 +157,7 @@ The subsections below state the normative rules. Cumulatively, they require the 
 
 The rules bind a trust framework that adopts this model; adoption itself is voluntary and per framework. They are written as conformance requirements so that adoption is testable, not because any framework is bound today. The Adoption section below sketches what adopting costs.
 
-The rules come in two kinds. The model rules (the bullet list in the next subsection) bind the trust framework's registry content: how qualifications, prerequisites, and the matrix are expressed. The numbered requirements (REQ-1 through REQ-10, further down) bind runtime behaviour on the wire: what an AT request must contain, what an issued AT must carry, and what the AS must verify. The REQ identifiers exist because these rules are individually testable; implementations and test suites reference them by number.
+The rules come in two kinds. The model rules (the bullet list in the next subsection) bind the trust framework's registry content: how qualifications, prerequisites, and the matrix are expressed. The numbered requirements (REQ-1 through REQ-8, further down) bind runtime behaviour on the wire: what an AT request must contain, what an issued AT must carry, and what the AS must verify. The REQ identifiers exist because these rules are individually testable; implementations and test suites reference them by number.
 
 #### Authorization information model
 
@@ -170,7 +170,7 @@ The normative model for layers 2 and 3 is the one shown in the Layer 2 and Layer
 - A SystemRolePrerequisite SHALL resolve a ServiceProvider's claims to a QualifiedSystemRole. A QualifiedSystemRole refines exactly one system role and covers one or more of the transactions that use that system role. Absent an explicit refinement, the QualifiedSystemRole SHALL default to the system role itself, covering all of that system role's transactions.
 - Every trust framework SHALL publish a PermissionMatrix per use case, mapping (AuthorizationRole, Transaction) to allow or deny plus a delegatable flag. The matrix MAY be trivial (an explicit allow for every resolved AuthorizationRole), but SHALL NOT be absent; the absence of an entry SHALL be treated as deny.
 - A trust framework MAY require a Membership claim (organisational admission to the framework or an information standard) for the HealthcareOrganization; prerequisites reference it like any other identity claim.
-- An AccessTokenRequest SHALL be scoped to exactly one Transaction and MAY narrow to a subset of the operations that realise that transaction.
+- An AccessTokenRequest SHALL be scoped to exactly one Transaction.
 - An AccessToken SHALL authorize exactly one Transaction.
 - A realisation catalogue MAY list state rules per operation, taken from the information standard's lifecycle; where it does, the resource server SHALL enforce them while handling the request.
 
@@ -199,47 +199,39 @@ Segment rules:
 - `tx`: literal marker, identifying this scope entry as a transaction identifier.
 - `<information-standard>`: the information-standard slug within the governance body (`mp` for Medicatieproces, `bgz`, `eoverdracht`, ...).
 - `<transaction>`: kebab-case transaction identifier (e.g. `verstrekkingsverzoek-raadplegen`).
-- `<version>`: hyphen-separated semantic version (`3-0-0`), or a single integer for major-only versioning (`3`). No `v` prefix, to match the operation token format below.
+- `<version>`: hyphen-separated semantic version (`3-0-0`), or a single integer for major-only versioning (`3`). No `v` prefix.
 
 The use case the transaction belongs to is derivable from the catalogue and is not carried on the wire.
 
-#### Operation identifier format
+#### The transaction identifier is an opaque string
 
-Operations are the fine-grained interactie-ids that may appear in the request scope alongside the transaction identifier, to narrow the granted scopes for least-privilege. Each must name one of the operations that realise the scoped transaction (the AS verifies this at issuance), and omitting them requests all of the transaction's operations. The general shape is `<verb>:<artifact>:<version>` (e.g. `search:mp-MedicationAgreement:1`); the exact format is information-standard-specific and registered in the realisation catalogue. The segment rules and the registered prefixes are listed in the [appendix](#appendix-operation-identifier-format-details).
-
-#### Scope entries are opaque strings
-
-For the purpose of policy matching, both the transaction identifier and the operation identifiers are treated as opaque strings: the AS looks them up in the trust framework's catalogue of registered transactions and operations, and matches against the policy by exact-string comparison. The format conventions are human-readable structure, not parsing requirements. Telling the two kinds apart (REQ-1, REQ-3) needs only a shape check: the transaction identifier is dot-separated with a `tx` marker; operation identifiers are colon-separated with a verb prefix.
+For the purpose of policy matching, the transaction identifier is treated as an opaque string: the AS looks it up in the trust framework's catalogue of registered transactions and matches against the policy by exact-string comparison. The format convention is human-readable structure, not a parsing requirement.
 
 #### Conformance: AT request
 
 > **REQ-1 (SHALL).** An AT request SHALL contain exactly one transaction identifier in its scope.
 >
 > **REQ-2 (SHALL).** The AS SHALL reject the request if REQ-1 is violated (zero or more than one transaction identifier).
->
-> **REQ-3 (MAY).** The request scope MAY contain operation identifiers (interactie-ids), each one naming an operation that realises the scoped transaction, to narrow the granted scopes for least-privilege.
->
-> **REQ-4 (SHALL).** The AS SHALL reject any operation identifier that does not name an operation realising the scoped transaction.
 
 #### Conformance: issued AT
 
-> **REQ-5 (SHALL).** The transaction identifier SHALL appear in the AT's `scope` alongside the granted SMART on FHIR scopes.
+> **REQ-3 (SHALL).** The transaction identifier SHALL appear in the AT's `scope` alongside the granted SMART on FHIR scopes.
 
 _Rationale: the `scope` member is standard in both JWT access tokens and introspection responses, so the transaction identifier is visible to the resource server and the audit subsystem without any non-standard field._
 
 #### Conformance: AS behaviour
 
-> **REQ-6 (SHALL).** The AS SHALL select the applicable PermissionMatrix entry by direct match of the transaction and the resolved AuthorizationRole, not by derivation from other scope entries or context.
+> **REQ-4 (SHALL).** The AS SHALL select the applicable PermissionMatrix entry by direct match of the transaction and the resolved AuthorizationRole, not by derivation from other scope entries or context.
 >
-> **REQ-7 (SHALL).** For the scoped transaction, the AS SHALL verify at issuance that:
+> **REQ-5 (SHALL).** For the scoped transaction, the AS SHALL verify at issuance that:
 >
 > - the ServiceProvider's claims (its Qualification and the ServiceProvider delegation) resolve, via a SystemRolePrerequisite, to a QualifiedSystemRole whose coverage includes the scoped transaction;
 > - the presented identity claims resolve, via a RolePrerequisite, to an AuthorizationRole that the PermissionMatrix permits for the transaction;
 > - if the AuthorizationRole is exercised under mandate (defined as: the organisation acting unattended, or a user acting under the professional's responsibility), then (a) the PermissionMatrix entry SHALL be delegatable, and (b) a HealthcareProfessional-to-HealthcareOrganization delegation SHALL authorize the business role the AuthorizationRole refines.
 >
-> **REQ-8 (SHALL).** The context checks of the scoped transaction's use case SHALL be enforced before data is released. The trust framework SHALL declare, per use case, the enforcement point of each check: the AS at token issuance, the AS at token introspection, or a policy decision point at the resource server. The AS SHALL evaluate the checks declared for issuance before issuing the AT.
+> **REQ-6 (SHALL).** The context checks of the scoped transaction's use case SHALL be enforced before data is released. The trust framework SHALL declare, per use case, the enforcement point of each check: the AS at token issuance, the AS at token introspection, or a policy decision point at the resource server. The AS SHALL evaluate the checks declared for issuance before issuing the AT.
 >
-> **REQ-9 (SHALL).** The AS SHALL reject the request if the transaction is unknown, any check in REQ-7 fails, or any context check declared for issuance fails.
+> **REQ-7 (SHALL).** The AS SHALL reject the request if the transaction is unknown, any check in REQ-5 fails, or any context check declared for issuance fails.
 
 #### Identity claims, context, and verification
 
@@ -254,9 +246,9 @@ In current Dutch implementations these claims appear in several forms, sometimes
 
 Which claims a request must carry follows from the prerequisites: exactly those the scoped transaction's RolePrerequisite and SystemRolePrerequisite read to resolve the AuthorizationRole and the QualifiedSystemRole. There is no separate required-claims list to maintain.
 
-**Context checks.** Role resolution answers "who is the requester"; the context checks answer "is sharing this patient's data allowed". They evaluate ContextClaims about the request rather than the requester: the patient (BSN), the Enrollment (the treatment relationship), consent, and purpose-of-use. Purpose-of-use is the requester's declared purpose for the request; it is distinct from the legal basis (grondslag) that makes sharing lawful, although the declared purpose determines which legal basis must hold. The checks are attached to the use case because the claims they evaluate concern the intent, which all the use case's transactions share; attaching identical checks per transaction would only duplicate them. A trust framework may narrow the checks for an individual transaction; it may never loosen them. Because a transaction belongs to exactly one use case, the scoped transaction fixes which checks apply. Where each check is enforced is declared per use case (REQ-8); the design notes discuss that choice.
+**Context checks.** Role resolution answers "who is the requester"; the context checks answer "is sharing this patient's data allowed". They evaluate ContextClaims about the request rather than the requester: the patient (BSN), the Enrollment (the treatment relationship), consent, and purpose-of-use. Purpose-of-use is the requester's declared purpose for the request; it is distinct from the legal basis (grondslag) that makes sharing lawful, although the declared purpose determines which legal basis must hold. The checks are attached to the use case because the claims they evaluate concern the intent, which all the use case's transactions share; attaching identical checks per transaction would only duplicate them. A trust framework may narrow the checks for an individual transaction; it may never loosen them. Because a transaction belongs to exactly one use case, the scoped transaction fixes which checks apply. Where each check is enforced is declared per use case (REQ-6); the design notes discuss that choice.
 
-> **REQ-10 (SHALL).** The client SHALL present the identity claims needed to resolve the AuthorizationRole and the QualifiedSystemRole for the scoped transaction, together with the ContextClaims required by the context checks declared for issuance (the use case's checks, possibly narrowed for the scoped transaction). The AS verifies these claims under REQ-7 and REQ-8 and rejects under REQ-9; an absent required claim fails the check that reads it.
+> **REQ-8 (SHALL).** The client SHALL present the identity claims needed to resolve the AuthorizationRole and the QualifiedSystemRole for the scoped transaction, together with the ContextClaims required by the context checks declared for issuance (the use case's checks, possibly narrowed for the scoped transaction). The AS verifies these claims under REQ-5 and REQ-6 and rejects under REQ-7; an absent required claim fails the check that reads it.
 
 ### Adoption
 
@@ -272,7 +264,7 @@ The model claims no new governance body. Each construct already exists in every 
 | DVA/DVP admission (MedMij) _(draft mapping, to be verified)_ | Qualification plus Membership |
 {:.grid .table-hover}
 
-The minimal first step is the transaction identifier format alone: it requires no registry changes beyond listing the identifiers, is visible on the wire, and gives audit and cross-framework tooling a uniform identifier. The full layer-2 publication can follow per framework, per information standard.
+The minimal first step is the transaction identifier format alone: it requires no registry changes beyond listing the identifiers, is visible on the wire, and gives audit and cross-framework tooling a uniform identifier. For AORTA-on-FHIR, whose request scopes today carry interactionIds, the transaction identifier replaces them rather than joining them. The full layer-2 publication can follow per framework, per information standard.
 
 Open issue: custodianship of the shared vocabulary (this chapter) once more than one framework adopts it. Candidates: Nictiz (owns layer 1), or the generieke functies programme. To be resolved with the trust framework architects.
 
@@ -280,9 +272,9 @@ Open issue: custodianship of the shared vocabulary (this chapter) once more than
 
 {% include authorization-model-evaluation.svg %}
 
-Happy path. Any check failure results in rejection; failure paths are omitted for clarity. The legend on the diagram marks each step's input sources: **R** for the AT request, **L1** for the information-layer catalogue, **L2** for the trust-layer registry, **L3** for the realisation-layer catalogue (the interactietabel). Steps that depend on derived context (e.g. "the required system role per operation") inherit their source from the step that resolved that context.
+Happy path. Any check failure results in rejection; failure paths are omitted for clarity. The legend on the diagram marks each step's input sources: **R** for the AT request, **L1** for the information-layer catalogue, **L2** for the trust-layer registry, **L3** for the realisation-layer catalogue (the interactietabel). Steps that depend on derived context (e.g. the transaction's required system role) inherit their source from the step that resolved that context.
 
-Because the AT is scoped to a single transaction, role resolution, the system-role coverage check, the matrix lookup, and the issuance-declared context checks are each evaluated once for that transaction; any operations in the request only narrow the granted scopes.
+Because the AT is scoped to a single transaction, role resolution, the system-role coverage check, the matrix lookup, and the issuance-declared context checks are each evaluated once for that transaction.
 
 ### Design notes
 
@@ -290,15 +282,25 @@ _This section is rationale, not specification: it argues the design decisions th
 
 #### Why the transaction is the scope unit
 
-- The _transaction_ is the grain at which the PermissionMatrix decides: each cell maps `(AuthorizationRole, Transaction)` to allow or deny. Scoping the AT to one transaction aligns the wire with the decision: the AS reads the transaction, resolves the role, and looks up one cell.
+- The _transaction_ is the unit the PermissionMatrix decides on: each cell maps `(AuthorizationRole, Transaction)` to allow or deny. Scoping the AT to one transaction aligns the wire with the decision: the AS reads the transaction, resolves the role, and looks up one cell.
 - The prerequisites are per transaction: which conditions must hold (the role resolution, the system-role coverage, the delegation, the context check) are set by the transaction. Bundling several transactions into one AT would mean satisfying the union of their prerequisites, which is awkward to express and can even conflict.
 - A _use case_ is too coarse for the AT scope: one AT would span many transactions with differing prerequisites, and an operation shared between them could not be attributed to a single cell. The use case is a catalogue grouping of transactions and the carrier of the context checks, not a key the matrix or the AT needs, and it does not appear on the wire.
-- An _operation_ is too fine: it is a wire-level interactie-id used for least-privilege scope granting, below the grain at which permission is decided. It is also reusable across transactions, so an operation alone does not identify the intent.
+- An _operation_ is too fine: permission is never decided per operation, and an operation is reusable across transactions, so it does not identify the intent on its own.
 - An AT covers one activity the requester performs (one transaction, e.g. `Raadplegen verstrekkingsverzoek`). A request that needs several transactions at once (a full medication overview for one patient) is served by an overview transaction such as Medicatieoverzicht, itself one transaction, or by issuing several ATs.
 
 This makes the wire chattier, and that cost is accepted deliberately. A viewer that opens the full Medicatiebouwstenen use case touches seven raadplegen transactions and therefore needs seven token requests, each a round trip to the source-side AS (the AS is usually co-located with the RS). Three things bound the cost. The requests are independent, so they can be issued in parallel. The issued AT is cacheable per (transaction, patient) within its lifetime, so the volume is per viewer session, not per screen refresh.
 
-Batching several transactions into one AT was considered and rejected. The prerequisites and the context checks are per transaction. A bundled AT must either satisfy every bundled transaction's conditions at once, which fails entirely when one check fails (and checks can conflict: consent may cover one data category but not another), or be evaluated loosely at bundle level. Loose evaluation erodes the per-transaction granularity of consent and audit; it is exactly the ambiguity this proposal removes. How many ATs one wire exchange may issue is a layer-3 profiling choice (a framework can adopt a batching or token-exchange profile without touching the model), as long as each issued AT stays scoped to one transaction.
+Batching several transactions into one AT was considered and rejected. The prerequisites and the context checks are per transaction. A bundled AT must either satisfy every bundled transaction's conditions at once, which fails entirely when one check fails (and checks can conflict: consent may cover one data category but not another), or be evaluated loosely at bundle level. Loose evaluation means consent and audit are no longer per transaction; it is exactly the ambiguity this proposal removes. How many ATs one wire exchange may issue is a layer-3 profiling choice (a framework can adopt a batching or token-exchange profile without touching the model), as long as each issued AT stays scoped to one transaction.
+
+#### Why the request carries no operation identifiers
+
+Letting the requester narrow the granted scopes by naming operation identifiers in the request scope was considered and rejected. The request and the response now split cleanly by vocabulary: the requester states its intent in the functional terms of layer 1 (the transaction), the AS translates that intent via the realisation catalogue, and the token returns the enforcement artefacts (the granted SMART on FHIR scopes). Three reasons:
+
+- The request convention becomes independent of the realisation. With operation identifiers in the request, changing the FHIR mapping changes the request format; without them, only the response side changes. The frameworks diverge most at the realisation layer, so this is what lets them share one request convention.
+- The client never needs the operation grammar. The requesting developer works with the information-standard catalogue; the AS and the realisation catalogue own the mapping; the resource server enforces the scopes.
+- Narrowing had no policy meaning. The permission decision is per transaction; requested operations could never change the allow or deny, only trim the granted scopes. That least-privilege gain is small (most transactions are realised by a single operation, and the token is short-lived, patient-bound, and transaction-bound) and does not cover the cost of a second identifier grammar on the wire.
+
+The removal has a real migration cost for AORTA: its current wire identifies work by interactionId, so this convention replaces those scope entries with a transaction identifier instead of adding one next to them. The Adoption section states this.
 
 #### Why consent, treatment relationship, and purpose live in layer 2
 
@@ -323,7 +325,7 @@ _Where._ The governing principle: a fact must surface as a wire claim exactly wh
 
 _When._ Evidence can bind at three moments: at ecosystem registration (the enforcer verified the fact when the member joined), at decision time from a registry (the AS consults a store of member claims when issuing the token), or presented with the message itself. The same layer-2 facts feed all three; the binding time should match the volatility of the fact. Qualifications change rarely, so registration-time verification suffices. Delegations change more often. The treatment relationship and consent are per-patient and per-moment, so they bind at decision time.
 
-_Which point for the context checks._ The context checks have no single right enforcement point: their inputs are per-patient and volatile, and where the evidence lives differs per deployment. The model therefore only requires that the trust framework declares the enforcement point of each check per use case (REQ-8): the AS at issuance, the AS at introspection time, or a policy decision point at the resource server. Introspection is worth singling out: there the resource server's runtime question is answered by the AS, so volatile facts can be re-evaluated on fresh data without the resource server holding any policy. Whatever the declared point, an undeclared check is a missing check; the declaration exists so that no party assumes the other one checked.
+_Which point for the context checks._ The context checks have no single right enforcement point: their inputs are per-patient and volatile, and where the evidence lives differs per deployment. The model therefore only requires that the trust framework declares the enforcement point of each check per use case (REQ-6): the AS at issuance, the AS at introspection time, or a policy decision point at the resource server. Introspection is worth singling out: there the resource server's runtime question is answered by the AS, so volatile facts can be re-evaluated on fresh data without the resource server holding any policy. Whatever the declared point, an undeclared check is a missing check; the declaration exists so that no party assumes the other one checked.
 
 The OAuth wire is asymmetric here: the request side has a claim-carrying convention (the AccessTokenRequest), the response side has none. A topology that wants a third party to verify source-side claims at response time therefore needs a wire convention that this proposal does not define. Verifying source-side claims at registration time or at token-issuance time avoids that gap, and fails before any data is assembled.
 
@@ -331,7 +333,7 @@ The OAuth wire is asymmetric here: the request side has a claim-carrying convent
 
 Every delegation in this model is the same mechanism: a party authorizes another to act with its authority, for a bounded period. The professional uses it in two ways. Acting in person, the professional delegates the use of their identity to the system they are logged into; the system asserts this with a UserAssertion naming the professional and their rolcode, valid for the working session. Acting under mandate, the professional has delegated the business role itself to the organisation: standing, valid until revoked; whoever operates the system, or the system running unattended, acts in the professional's name.
 
-The two uses differ in duration and in what is conveyed (an identity versus a business role). The model keeps them apart for one reason only: under mandate the authenticated actor, if there is one, is not the role holder. The PermissionMatrix keys on that fact with its delegatable flag, and REQ-7 tests it. Attended means a UserAssertion is present. For the audit trail the distinction changes nothing: the source logs the acting individual where one exists, and the mandate where one is used.
+The two uses differ in duration and in what is conveyed (an identity versus a business role). The model keeps them apart for one reason only: under mandate the authenticated actor, if there is one, is not the role holder. The PermissionMatrix keys on that fact with its delegatable flag, and REQ-5 tests it. Attended means a UserAssertion is present. For the audit trail the distinction changes nothing: the source logs the acting individual where one exists, and the mandate where one is used.
 
 ### Examples
 
@@ -339,11 +341,10 @@ _This section is non-normative._ Each example shows the request scope, the AS de
 
 #### Worked example: a GP consults a patient's medication agreements
 
-**Use case** Medicatiebouwstenen, **transaction** Raadplegen medicatieafspraak. The request scope is one transaction identifier plus, optionally, the operation identifiers that narrow the granted scopes:
+**Use case** Medicatiebouwstenen, **transaction** Raadplegen medicatieafspraak. The request scope is the transaction identifier:
 
 ```
 aorta.tx.mp.medicatieafspraak-raadplegen.3-0-0
-search:mp-MedicationAgreement:1
 ```
 
 **Layer-2 registry for this transaction**
@@ -379,11 +380,11 @@ _`PermissionMatrix`_ (slice for this transaction), keyed on `(AuthorizationRole,
 
 The rolcode discriminator is what lets the matrix differ per rolcode set even within one business role: here a verpleegkundige is denied, and for the sibling transaction `Beschikbaarstellen medicatieafspraak` the Autorisatierichtlijn permits artsen but not apothekers.
 
-_Context checks (on the use case)._ Medicatiebouwstenen requires, for this patient, an Enrollment (treatment relationship) and a Mitz consent that permits sharing medication data. ContextClaims: `patient` (BSN), `Enrollment`, `mitzConsent`. In this example both checks are declared for issuance (REQ-8).
+_Context checks (on the use case)._ Medicatiebouwstenen requires, for this patient, an Enrollment (treatment relationship) and a Mitz consent that permits sharing medication data. ContextClaims: `patient` (BSN), `Enrollment`, `mitzConsent`. In this example both checks are declared for issuance (REQ-6).
 
 **AS decision.** A huisarts requests it, authenticated and in the loop (attended). Role resolution: `rolcode=01.015` is in the `MedicatieRaadplegerArts` set, so the role resolves to `MedicatieRaadplegerArts`; no delegation is involved. System-role pipeline: the Qualification and the ServiceProvider delegation both name `MedicatieafspraakRaadplegend`, so the QualifiedSystemRole resolves and covers the scoped transaction. Matrix: `(MedicatieRaadplegerArts, Raadplegen medicatieafspraak)` = allow, delegatable. Context checks: treatment relationship and Mitz consent pass. The AT is issued. Had the organisation's system made this request unattended (a background refresh, say), the role would only resolve with a HCP-to-HCO delegation naming `Medicatieraadpleger`, and only because the matrix cell says `delegatable = yes`.
 
-**Issued AT (introspection).** The AS grants the SMART on FHIR scope for the requested operation (`mp-MedicationAgreement` maps to FHIR `MedicationRequest`):
+**Issued AT (introspection).** The AS grants the SMART on FHIR scope derived from the transaction's realising operation, `search:mp-MedicationAgreement:1` (`mp-MedicationAgreement` maps to FHIR `MedicationRequest`):
 
 ```json
 {
@@ -423,10 +424,9 @@ medmij.tx.mp.medicatieafspraak-raadplegen.1-0
 
 ```
 aorta.tx.mp.medicatievoorschrift-sturen.3-0-0
-transaction:mp-MedicationPrescriptionProcessing-Bundle:1
 ```
 
-Role resolution resolves `AuthorizationRole = VoorschrijverArts` (`rolcode=01.015`; the voorschrijver is the authenticated principal, so no delegation); the system-role pipeline passes on system role `VoorschriftSturend` (Qualification and ServiceProvider delegation both naming it, no refinement involved); the matrix permits `(VoorschrijverArts, Sturen medicatievoorschrift)`; the AS grants write scopes for the bundle operation.
+Role resolution resolves `AuthorizationRole = VoorschrijverArts` (`rolcode=01.015`; the voorschrijver is the authenticated principal, so no delegation); the system-role pipeline passes on system role `VoorschriftSturend` (Qualification and ServiceProvider delegation both naming it, no refinement involved); the matrix permits `(VoorschrijverArts, Sturen medicatievoorschrift)`; the AS grants the write scopes derived from the transaction's bundle operation (`transaction:mp-MedicationPrescriptionProcessing-Bundle:1`).
 
 ```json
 {
@@ -440,42 +440,6 @@ Role resolution resolves `AuthorizationRole = VoorschrijverArts` (`rolcode=01.01
   "iat": 1759999100
 }
 ```
-
-### Appendix: operation identifier format details
-
-The operation identifier format adopts the `interactionId` shape of the [AORTA-on-FHIR interactietabel](https://aorta-on-fhir.public.vzvz.nl/aorta-on-fhir-specificaties/Working-version/aorta-interactietabel). Two shapes exist:
-
-```
-<verb>:<artifact>:<version>                       AORTA-internal style
-<verb>:<artifact>:<version>:<request|response>    MedMij / PHR-facing style (PHR = Personal Health Record, the citizen-side PGO)
-```
-
-Examples (taken from the AORTA interactietabel for Medicatieproces 9):
-
-```
-search:mp-MedicationAgreement:1
-search:mp-MedicationDispense:1
-search:mp-AdministrationAgreement:1
-search:mp-MedicationUse2:1
-create:mp-MedicationAgreement:1
-transaction:mp-MedicationPrescriptionProcessing-Bundle:1
-search:MedicationStatement:1.0:request
-```
-
-Segment rules:
-
-- `<verb>` is one of the FHIR interaction types from the closed set: `create`, `read`, `update`, `delete`, `search`, `batch`, `transaction`, `operation`. The verb determines the wire semantics: `transaction` is the FHIR transaction interaction (an atomic `Bundle` POST with `type=transaction`), unrelated to the Nictiz transaction of layer 1; `batch` is the looser-consistency sibling, `search` is FHIR search, and so on. Where this chapter means the verb, it writes "FHIR transaction interaction" in full.
-- `<artifact>` identifies the target. It is either a bare FHIR resource type (PHR/MedMij interactions, e.g. `MedicationStatement`) or a profile name with a programme prefix. Prefixes seen in the AORTA interactietabel:
-  - `zib-` for a Zorginformatiebouwsteen profile (`zib-MedicationAgreement`, `zib-LivingSituation`)
-  - `mp-` for a Medicatieproces v9 artifact (`mp-MedicationDispense`, `mp-MedicationPrescriptionProcessing-Bundle`)
-  - `mp612-` for a Medicatieproces v6.12 conversion artifact
-  - `twiin-` for a Twiin infrastructure artifact (`twiin-TaskNotifiedPull`)
-  - `aorta-` for an AORTA infrastructure artifact (`aorta-DataReference`)
-  - The set is open-ended; new information standards may introduce their own prefix.
-- `<version>` is the version of the interactie definition itself, not of the zib or FHIR resource. Bare integer for AORTA-internal style (`1`, `2`); dotted decimal for MedMij-facing style (`1.0`). This matches the version format of the transaction identifier (numeric, no `v` prefix).
-- `<request|response>` (MedMij style only) marks the direction of the message in a paired exchange.
-
-The exact shape of the operation identifier is information-standard-specific: each information standard registers its own artifact prefixes and version conventions. New information standards are encouraged to follow the `<verb>:<artifact>:<version>` shape above for cross-framework consistency, but the proposal does not mandate it.
 
 ### Glossary
 
@@ -492,12 +456,12 @@ Translation table for the information-layer (L1) catalogue terms:
 | Qualification          | kwalificatie        |
 {:.grid .table-hover}
 
-- **AccessTokenRequest**: the OAuth 2.0 request sent by the ServiceProvider to the AS, carrying the transaction identifier (`tx`), optional operation identifiers, asserted identity claims, and context claims.
+- **AccessTokenRequest**: the OAuth 2.0 request sent by the ServiceProvider to the AS, carrying the transaction identifier (`tx`), asserted identity claims, and context claims.
 - **AS**: Authorization Server, issues access tokens.
 - **AT**: Access Token.
 - **AuthorizationRole**: the subject the PermissionMatrix keys on; one business role refined by a set of identity claims (typically rolcodes), resolved from presented claims by a RolePrerequisite.
 - **Business role** (bedrijfsrol): the role a person plays in a transaction (Voorschrijver, Verstrekker, Toediener, ...). Unit of HealthcareProfessional-to-HealthcareOrganization delegation, and the role an AuthorizationRole refines.
-- **Context check**: a per-use-case rule that evaluates ContextClaims; its enforcement point (AS at issuance, AS at introspection, or a policy decision point at the resource server) is declared per use case (REQ-8).
+- **Context check**: a per-use-case rule that evaluates ContextClaims; its enforcement point (AS at issuance, AS at introspection, or a policy decision point at the resource server) is declared per use case (REQ-6).
 - **ContextClaim**: a typed assertion about the request context rather than the requester (patient, Enrollment, consent, purpose-of-use), evaluated by the use case's context checks.
 - **Credential**: a set of one or more claims made by an issuer, in the W3C Verifiable Credentials sense of the term (not the NIST sense). This chapter writes credential where claims travel bundled as one artefact (the two delegations) and claim for a single assertion.
 - **Dataset**: a tree of dataset concepts; either a primary dataset of an information standard or an imported building-block dataset (such as a zib).
@@ -509,7 +473,7 @@ Translation table for the information-layer (L1) catalogue terms:
 - **Information standard** (informatiestandaard): a healthcare information standard (e.g. Medicatieproces, BgZ), in the Netherlands mostly maintained by Nictiz.
 - **Legal basis** (grondslag): the legal ground that makes sharing lawful (consent, treatment relationship, statutory duty). Distinct from purpose-of-use.
 - **Membership**: the claim by which a HealthcareOrganization asserts admission to a trust framework or an information standard within it; the organisational counterpart of the Qualification (deelnemersovereenkomst, aansluitvoorwaarden).
-- **Operation**: a single wire-level interaction (`<verb>:<artifact>:<version>`), the interactionId of the AORTA-on-FHIR interactietabel. A layer-3 realisation construct, reusable across transactions; not a layer-1 concept.
+- **Operation**: one FHIR interaction (search, create, ...) performed on the FHIR profile that represents a transaction's data. The unit in which the realisation catalogue maps a transaction onto FHIR, identified by an interactionId (the AORTA-on-FHIR interactietabel shape); reusable across transactions. A layer-3 concept; it does not appear in the request scope.
 - **PDP**: Policy Decision Point, see [Authorization](authorization.html).
 - **PermissionMatrix**: a layer 2 entity, per use case, mapping (AuthorizationRole, Transaction) to allow or deny plus a delegatable flag. Always present; may be trivial (explicit allow-all); an absent entry is deny. The AORTA realisation for medication is the _Autorisatierichtlijn medicatieveiligheid_.
 - **Purpose-of-use**: the requester's declared purpose for a request (treatment, emergency, ...), a ContextClaim. Distinct from the legal basis; the declared purpose determines which legal basis must hold.
@@ -522,7 +486,7 @@ Translation table for the information-layer (L1) catalogue terms:
 - **State rule**: a rule from the information standard's lifecycle restricting an operation to given data states and roles, listed in the realisation catalogue and enforced by the resource server while handling the request. Never carried on the access token.
 - **System role** (systeemrol): the role a system plays in a transaction (Sturend, Ontvangend, Raadplegend, Beschikbaarstellend). Unit of qualification and of ServiceProvider delegation.
 - **SystemRolePrerequisite**: a layer 2 rule that resolves a ServiceProvider's claims (notably its Qualification and delegation) to a QualifiedSystemRole; the system-role counterpart of a RolePrerequisite, with no matrix.
-- **Transaction** (transactie): a single interaction within a transaction group, e.g. `Raadplegen verstrekkingsverzoek` (the consumer queries a source) or `Beschikbaarstellen verstrekkingsverzoeken` (the source returns the requested data). The leaf functional unit of layer 1 and the unit the PermissionMatrix authorizes against; belongs to exactly one use case. Not to be confused with the FHIR transaction interaction (an atomic `Bundle` POST), which appears as a verb in operation tokens.
+- **Transaction** (transactie): a single interaction within a transaction group, e.g. `Raadplegen verstrekkingsverzoek` (the consumer queries a source) or `Beschikbaarstellen verstrekkingsverzoeken` (the source returns the requested data). The leaf functional unit of layer 1 and the unit the PermissionMatrix authorizes against; belongs to exactly one use case. Not to be confused with the FHIR transaction interaction (an atomic `Bundle` POST), which appears as a verb in operation identifiers.
 - **Transaction dataset** (transactiedataset): the subset of dataset concepts a transaction selects, each optionally restricted (conformance, cardinality, condition) relative to its baseline.
 - **Transaction group** (transactiegroep): a named group of related transactions, e.g. `Verstrekkingsverzoek (raadplegen/beschikbaarstellen)`.
 - **Transaction identifier**: the identifier of the scoped transaction, carried in the OAuth `scope` of the AT request and the issued AT; format `<governance-body>.tx.<information-standard>.<transaction>.<version>`.

--- a/input/pagecontent/authorization-model.md
+++ b/input/pagecontent/authorization-model.md
@@ -6,140 +6,161 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 ### Introduction
 
-Dutch healthcare data exchange runs under several authorization regimes (AORTA-on-FHIR, MedMij, Twiin, Nuts use-case communities). Each one has, over time, built its own internal authorization model: its own vocabulary for qualifications, its own delegation structures, its own scope-token grammar, its own way of pairing identity claims with policy. The models overlap conceptually, but never align. Cross-framework integration is therefore expensive and brittle.
+Dutch healthcare data exchange runs under several trust frameworks (AORTA-on-FHIR, MedMij, Twiin, Nuts use-case communities). Each one has, over time, built its own authorization model. Each model is well documented within its own framework. But it is framework-local: it lives spread over registry definitions, policy documents, and wire conventions, in a vocabulary that only works inside that framework. No shared national model exists. The models overlap conceptually: qualifications, delegations, roles, and context checks appear in all of them. Yet they never align, and there is no shared vocabulary to compare them in.
 
-This chapter proposes a shared *authorization information model* and derives one concrete OAuth 2.0 wire convention from it. The model is layered: a layer 1 that adopts the Nictiz "Handleiding Wiki documentatie" structure verbatim, and a layer 2 that adds the authz-specific concepts that the Nictiz model does not address (qualifications, delegations, identity claims, the access token itself).
+This proposal makes the model explicit. It defines a shared _authorization information model_, layered on top of the Nictiz information-standard catalogue, and derives one concrete OAuth 2.0 wire convention from it.
 
-The intended audience is architects of the trust frameworks listed above. The proposal is independent of how identity claims are attested. In current Dutch implementations identity claims appear in several forms, sometimes mixed within one request: signed claims in SAML tokens, Verifiable Credentials, JWT claims issued by a trusted Authorization Server, and claims derived from an mTLS client certificate. The proposal works with any of these; it does not prescribe a wire format.
+The intended audience is architects of the trust frameworks listed above. The proposal is independent of how identity claims are attested and does not prescribe a wire format; the Specification lists the attestation forms in use today.
 
-### Background
+A note on terminology: this chapter uses English terms for the Nictiz catalogue concepts (transaction, system role, business role); the glossary contains the translation table. Concrete catalogue values (transaction names, role names, rolcodes) are quoted in their original Dutch.
 
-#### Layered model
+### Problem
 
-Three layers are involved in defining how authorization works for Dutch healthcare data exchange:
+Each trust framework documents its own authorization model, but only its own. Four constructs recur in every framework, under different names, at different granularities, with different attestation formats:
 
-- **Layer 1, Information Standards (Nictiz)** defines *what* transactions exist. Owned by Nictiz via the [Handleiding Wiki documentatie](https://informatiestandaarden.nictiz.nl/wiki/Handleiding_Wiki_documentatie). Catalogues informatiestandaarden, use cases, transactiegroepen, transacties, systeemrollen, bedrijfsrollen, and the zibs they operate on. The same for all trust frameworks.
-- **Layer 2, Trust Framework** specifies *who* may perform *which* transactions, and under what conditions. Owned by the trust frameworks (VZVZ, MedMij, Twiin, Nuts working groups) and by this IG. Adds the governance constructs that gate access: authentication profiles, authorization policies, qualifications, the delegation chain, identity claims, and the actor model.
-- **Layer 3, OAuth wire** specifies *how* a single authorization decision surfaces in an OAuth 2.0 exchange. The access-token request, the issued access token, and the minted SMART on FHIR scopes that the resource server enforces.
+- **Qualification**: every framework has a mechanism that admits a vendor product into a technical role, but each framework names a different part of that mechanism. AORTA names the registry that records the result of a successful qualification (TKID); MedMij names the roles a successful qualification admits a party into (DVA, DVP); Twiin has similar mechanisms. None separates the qualification from the role it leads to.
+- **Delegation chain**: AORTA, MedMij, and Twiin each construct delegation chains between professionals, organisations, and service providers differently. The chain shape is usually similar; the attestations and granularities are not.
+- **Role resolution**: every framework maps presented identity claims (rolcodes, organisation identifiers) onto something it permits actions for, but the mapping rules are buried in framework-specific policy documents such as the Autorisatierichtlijn, with no common structure.
+- **Context checks**: consent (Mitz), the treatment relationship, and purpose-of-use gates exist everywhere, attached at different points in each framework and with no shared vocabulary (an explicit purposeOfUse field in the Nuts authorization credential, the distinct spoed situation in Mitz).
 
-This chapter proposes a uniform model for layers 2 and 3. Layer 1 is taken as given.
+Because each model is stated only in its own framework's terms, the models cannot be compared, mapped, or composed. A developer building a system that participates in two frameworks must assemble two complete models from documentation scattered across wikis, registries, and policy documents, and invent the mapping between them. A policy author cannot tell whether two frameworks make the same access decision for the same situation. This is the core problem: cross-framework integration is expensive and brittle.
 
-#### Layer 1: Information Standards (Nictiz)
+The divergence is most visible on the OAuth wire: each framework identifies the authorized work in the request scope with a different grammar, and differs in whether that identification survives onto the issued access token. The wire divergence is only the visible part: the grammars differ because each framework derived its wire convention from a different underlying model. Aligning the syntax without aligning the model would change nothing. This proposal therefore defines the model first, and the wire convention as its consequence.
+
+### The model
+
+The Examples section shows every construct introduced below as a filled-in table, for one concrete case (a GP consults a patient's medication agreements). Reading the model and that example side by side is the fastest route through this chapter.
+
+#### Three layers
+
+This proposal models authorization in three layers. The layering is a modelling decision, not a given: it is chosen because the layers have different owners, change at different rates, and answer different questions. A layer groups concerns, not authors; one governance body can author artefacts in more than one layer.
+
+- **Layer 1, Information Standards** defines _what_ transactions exist and _what data_ they carry. In the Netherlands most information standards are maintained by Nictiz; this proposal adopts the Nictiz meta-model, per the [Handleiding Wiki documentatie](https://informatiestandaarden.nictiz.nl/wiki/Handleiding_Wiki_documentatie), as the layer-1 vocabulary. It catalogues information standards, use cases, transaction groups, transactions, system roles, business roles, and the datasets they operate on. The same for all trust frameworks.
+- **Layer 2, Trust Framework** specifies _who_ may perform _which_ transactions, and under what conditions: role resolution, the permission matrix, qualifications, the delegation chain, identity claims, context claims. Today these constructs are filled per framework (VZVZ, MedMij, Twiin, Nuts-toepassingen). The model does not tie them to per-framework governance: with a shared vocabulary, layer-2 policies can be lifted to national governance where that is wanted.
+- **Layer 3, Realisation and OAuth wire** specifies _how_ a transaction reaches the wire: the FHIR profiles that represent its data, the wire-level operations that carry it, and how a single authorization decision surfaces in an OAuth 2.0 exchange. The wire artefacts are the access-token request, the issued access token, and the minted SMART on FHIR scopes that the resource server enforces.
+
+This proposal defines a uniform model for layers 2 and 3. Layer 1 is taken as given.
+
+#### Layer 1: Information Standards
 
 {% include authorization-model-nictiz.svg %}
 
 Hierarchy from outer to inner:
 
-- **Informatiestandaard**: top container (e.g. Medicatieproces 9). Owned by Nictiz.
-- **Use case**: a sub-chapter of an informatiestandaard, equal to a "scenario" in ART-DECOR. Coarse business framing.
-- **Transactiegroep**: a named group of related transacties, e.g. `Verstrekkingsverzoek (raadplegen/beschikbaarstellen)`, bundling the `Raadplegen verstrekkingsverzoek` and `Beschikbaarstellen verstrekkingsverzoek` transacties.
-- **Transactie**: a single interaction within a transactiegroep, e.g. `Raadplegen verstrekkingsverzoek` (consult or request from a source) or `Beschikbaarstellen verstrekkingsverzoek` (publish, for instance to an index). FHIR or CDA profiles attach at this level.
-- **Operation** (interactie-id on the wire): a single wire-level operation within a transactie, identified as `<verb>:<artifact>:<version>` (e.g. `search:zib-MedicationAgreement:2`). One transactie has one or more operations; an artifact is a Zib or a FHIR Bundle profile.
-- **Systeemrol**: the role a system plays in a transactie. Four kinds: Sturend, Ontvangend, Raadplegend, Beschikbaarstellend. Unit of qualification.
-- **Bedrijfsrol**: the role a person plays in a transactie (Voorschrijver, Verstrekker, ...). Cross-cutting actor type.
+- **Information standard** (informatiestandaard): top container (e.g. Medicatieproces 9).
+- **Use case**: a sub-chapter of an information standard. Coarse business framing. The use case defines the intent; each transaction, belonging to exactly one use case, inherits it.
+- **Transaction group** (transactiegroep): a named group of related transactions, e.g. `Verstrekkingsverzoek (raadplegen/beschikbaarstellen)`, bundling the `Raadplegen verstrekkingsverzoek` and `Beschikbaarstellen verstrekkingsverzoeken` transactions.
+- **Transaction** (transactie): a single interaction within a transaction group. The transactions in a group form an exchange: in a pull exchange, `Raadplegen verstrekkingsverzoek` (the consumer queries a source; type `initial`) pairs with `Beschikbaarstellen verstrekkingsverzoeken` (the source returns the requested data; type `back`). A push exchange pairs a `Sturen ...` transaction with its receipt confirmation. The leaf functional unit: nothing sits between the transaction and the data it selects.
+- **System role** (systeemrol): the role a system plays in a transaction (Raadplegend, Beschikbaarstellend, Sturend, Ontvangend, possibly refined per subject). Unit of qualification.
+- **Business role** (bedrijfsrol): the role a person plays in a transaction (Voorschrijver, Verstrekker, ...). Cross-cutting actor type.
+- **Dataset** and **DatasetConcept**: the data definitions. An information standard defines its primary datasets; building-block datasets (zibs) are defined by other standards and imported. A dataset is a tree of concepts (groups and items); a transaction selects a subset of those concepts and restricts them. That selection is the _transaction dataset_ (transactiedataset).
 
-The **use case is the unit of authorization** in this proposal. A single user-facing data request often needs operations from more than one transactiegroep within the same use case. For example, the *Medicatiebouwstenen* use case in Medicatieproces 9 contains `Medicatiegebruik (raadplegen/beschikbaarstellen)` and `Medicatietoediening (raadplegen/beschikbaarstellen)` among others; a "show me everything about this patient's medication" view needs operations from both. Scoping the AT at the use-case level reflects that. The transactiegroep remains the unit of conformity (qualification, policy granularity per direction), but is not surfaced on the OAuth wire.
+Two structural points matter for authorization:
+
+- **Containment, not reuse.** A transaction group belongs to one use case, and a transaction to one transaction group, so a transaction belongs to exactly one use case. Reuse across standards happens at the dataset, template, and value-set level, not at the transaction level. Fetching the same data under a different use case is, by definition, a different transaction, because the use case carries the intent and therefore the conditions.
+- **There is no operation concept in layer 1.** The functional model stops at the transaction. The fine-grained wire-level operations are realisation constructs and are introduced in layer 3.
+
+The transaction dataset itself shows which constructs belong in layer 2; the design notes contain that derivation.
 
 #### Layer 2: Trust Framework
 
-Layer 2 is where the trust framework adds the constructs that gate access on top of the Nictiz catalogue. It is presented in two views: first the general mechanism that turns presented claims into an access decision, then the concrete actors and credentials that supply those claims in the Dutch context. In both diagrams, Nictiz catalogue entities are shown in yellow (referenced from layer 1, not redefined here), trust-framework policy and actors in pale blue, and identity claims and credentials in mid-blue.
+Layer 2 adds the constructs that gate access on top of the layer-1 catalogue. It is presented in two views: first the concrete actors and the credentials that carry their claims in the Dutch context, then the general mechanism that turns those claims into an access decision. In both diagrams, layer-1 catalogue entities are shown in yellow (referenced, not redefined here), trust-framework policy and actors in pale blue, and identity claims in mid-blue.
+
+**Actors and credentials.**
+
+This view shows who the actors are, the credentials carrying the identity claims that the access decision consumes, and the context claims (such as the Enrollment) the actors produce.
+
+{% include authorization-model-layer2.svg %}
+
+- **HealthcareProfessional, HealthcareOrganization, ServiceProvider**: the three professional-side actor layers. The professional is employed by an organisation; the organisation is served by a service provider.
+- **Patient**: the data subject, referenced via their BSN in the `patient` attribute of the AccessTokenRequest. In professional flows the request principal is the ServiceProvider acting for the professional and the organisation; in patient-channel (PHR) flows the patient is also the authenticated principal, requesting via their PGO (see the MedMij example).
+- **IdentityClaim** (abstract): a typed assertion about the requester. Generalises rolcode, organisation identifiers, the system-role or business-role assertion, the Qualification, the Membership, and the two delegations. Each trust framework defines its own vocabulary.
+- **Qualification**: the claim by which a ServiceProvider asserts that its product passed qualification for a given system role. The qualification itself is an upstream certification process; the claim asserts its result. AORTA records qualification results in TKID; a successful MedMij qualification admits the party into the DVA (provider-side) or DVP (PGO-side) role.
+- **HealthcareProfessional-to-HealthcareOrganization delegation**: the credential by which a professional delegates a set of business roles to their organisation. It is the _mandaattoken_ behind the matrix's `delegatable` flag. It is needed whenever the role is exercised by someone other than the professional who holds it: the organisation acting unattended, or an authenticated user who lacks the required rolcode and works under the professional's responsibility. A professional with the required rolcode asserts the role directly. Whether the delegation surfaces as a wire credential at all depends on the enforcement topology (below).
+- **ServiceProvider delegation**: the credential by which an organisation delegates a set of system roles to its service provider.
+- **Membership**: the claim by which a HealthcareOrganization asserts its admission to a trust framework, or to a specific information standard within it. The organisational counterpart of the Qualification: where the Qualification certifies a product for a system role, the Membership certifies that the organisation meets the framework's non-technical requirements (participation agreements, security and privacy norms). Realisations: the MedMij and Twiin deelnemersovereenkomst, AORTA's aansluitvoorwaarden. Prerequisites reference it like any other identity claim; it is slow-changing and typically binds at registration time.
+- **ContextClaim** (abstract) and **Enrollment**: assertions about the request and the patient, not the requester. `Enrollment` is the treatment relationship: the professional issues it to the organisation, attesting that they enrol or treat the patient. It feeds the use-case context gate, not role resolution.
+
+The delegation chain runs at two layers: the professional-to-organisation delegation at business-role level, the service-provider delegation at system-role level. Each step delegates only what it can express; a professional is not a system, so cannot delegate a system role. The identity claims feed the role resolution below; the context claims, such as the Enrollment, feed the use-case context gate.
 
 **Role resolution and permission.**
 
 {% include authorization-model-role-resolution.svg %}
 
-Authorization is decided in two decoupled steps. First, *role resolution*: a `RolePrerequisite` resolves the identity claims a requester presents to an `AuthorizationRole`, which is one Nictiz `Bedrijfsrol` refined by a set of claims (typically rolcodes). A role may have several RolePrerequisites and satisfying any one is enough, so a new credential route can be added without touching the permission rules; this also subsumes the presence check (the required claim types are exactly what the prerequisites read). Second, *permission*: the `PermissionMatrix` keys on the `AuthorizationRole` and the `Transactie` and yields allow or deny plus a `delegatable` flag. The AORTA realisation of the matrix is the *Autorisatierichtlijn medicatieveiligheid*, a table mapping (rolcode, transactie) to ja/nee.
+Authorization is decided in two decoupled steps on the professional side. First, _role resolution_: a `RolePrerequisite` resolves the presented identity claims to an `AuthorizationRole`, one business role refined by a set of claims (typically rolcodes). A role may have several prerequisites, and satisfying any one resolves the role; adding a new way to prove the same role means adding a prerequisite, without touching the permission rules. Second, _permission_: the `PermissionMatrix` keys on the `AuthorizationRole` and the `Transaction` and yields allow or deny plus a `delegatable` flag.
 
-The system side mirrors the first step but needs no matrix: a `SysteemrolPrerequisite` resolves the product's claims (its qualification) directly to a `Systeemrol`. Because Nictiz defines a fine-grained systeemrol per transactie endpoint, being qualified for the systeemrol already is per-transactie permission; the matrix is only needed on the professional side, where the bedrijfsrol is coarse.
+The PermissionMatrix is always present, but its content may be trivial. The AORTA realisation for medication is the _Autorisatierichtlijn medicatieveiligheid_, a table mapping (rolcode, transaction) to ja/nee. Acute Zorg and Labuitwisseling have no such policy; they attach professions directly to transactions. A standard without a policy realises the matrix as an explicitly published allow-all over its resolved roles. The matrix is never absent and an absent entry is always deny; "no policy" is expressed as a trivial matrix, not as a missing one.
 
-**Actors and credentials.**
+The system side is evaluated independently of the professional side; the model implies no order between them. In the common case it is one check: the Qualification and the ServiceProvider delegation (both introduced above) must name the transaction's system role. That suffices because the transaction itself declares which system role it involves. No matrix is needed: naming the system role is naming the permitted transactions. In the diagram, both sides therefore end in an edge to the Transaction, and both edges mean the same thing: permission. The professional side mediates that permission through the matrix, because a business role carries no per-transaction verdicts; those are policy, such as the Autorisatierichtlijn.
 
-Role resolution treats the claims abstractly. This view fills that in for the Dutch context: who the actors are, the credentials carrying the identity claims that role resolution consumes, and the context claims (such as the Enrollment) the actors produce for the context gate.
+One refinement exists, for standards whose system roles are coarse. Medicatieproces 9 defines roughly fifty system roles, one per subject-activity pair (e.g. `MedicatieafspraakRaadplegend`), so naming the system role pins down a single transaction and nothing more is needed. A standard with a handful of generic system roles would grant every transaction of the role with one qualification. For that case the trust framework MAY define a `QualifiedSystemRole`: a refinement of one system role that covers only a subset of its transactions. The `SystemRolePrerequisite` then resolves the ServiceProvider's claims to that refined role. Absent a refinement, the qualification grants every transaction of the system role. The two layer-2 roles compare as follows:
 
-{% include authorization-model-layer2.svg %}
+|                 | AuthorizationRole                | QualifiedSystemRole                               |
+| --------------- | -------------------------------- | ------------------------------------------------- |
+| refines         | one business role                | one system role                                   |
+| refinement axis | requester claims (rolcodes)      | transaction coverage                              |
+| answers         | who counts as this role          | which transactions does this qualification grant  |
+| default         | none; every role must be defined | no refinement; grants all the role's transactions |
+| permission via  | PermissionMatrix cell            | coverage directly permits                         |
+{:.grid .table-hover}
 
-- **HealthcareProfessional, HealthcareOrganization, ServiceProvider**: the three professional-side actor layers. The professional is employed by an organisation; the organisation is served by a service provider.
-- **Patient**: the data subject. In professional flows the patient is referenced via their BSN as the data-scope of the access token; the request principal is the ServiceProvider acting for the HealthcareProfessional and HealthcareOrganization. In *patient-channel (PHR) flows* the patient becomes the asserting principal: they authenticate via DigiD with their PGO, and the PGO operator (a ServiceProvider qualified as a Dienstverlener Persoon under MedMij) makes the access-token request on their behalf. In both flows the `patient` attribute on the AccessTokenRequest carries the data-subject BSN; in PHR flows that BSN coincides with the authenticating principal's BSN.
-- **IdentityClaim** (abstract): a typed assertion about the requester. Generalises rolcode, organisation identifiers, the systeemrol or bedrijfsrol assertion, the Qualification and the two delegations. Each trust framework defines its own vocabulary.
-- **Qualification**: certifies that a vendor product (used by a service provider) may act in a given systeemrol. AORTA term: kwalificatie, recorded in TKID; MedMij splits it into DVA (provider-side) and DVP (PGO-side).
-- **HealthcareProfessional-to-HealthcareOrganization delegation**: the credential by which a professional delegates a set of bedrijfsrollen to their organisation. It is the *mandaattoken* behind the matrix's `delegatable` flag.
-- **ServiceProvider delegation**: the credential by which an organisation delegates a set of systeemrollen to its service provider.
-- **ContextClaim** (abstract) and **Enrollment**: assertions about the request and the patient, not the requester. `Enrollment` is the treatment relationship: the professional issues it to the organisation, attesting that they enrol or treat the patient. It feeds the use-case context gate, not role resolution.
+**The patient channel.** The same machinery covers the citizen. The patient is an actor whose RolePrerequisite reads the DigiD-authenticated BSN claim and resolves to an AuthorizationRole refining the business role Patiënt. The PermissionMatrix rows for that role are the framework's allow-set for patient access (in MedMij terms: the gegevensdiensten). The system side is unchanged: the PGO operator is the ServiceProvider, its Qualification is the DVP admission, and the delegation is issued by the patient rather than by an organisation. The context gate degenerates: there is no treatment relationship, and consent is inherent in requesting one's own data. What remains is the data-subject equality check: the authenticated BSN must equal the `patient` attribute. The MedMij example in the Examples section shows the resulting token.
 
-The delegation chain runs at two layers: the professional-to-organisation delegation at bedrijfsrol level, the service-provider delegation at systeemrol level. Each step delegates only what it can express; a professional is not a system, so cannot delegate a systeemrol. The identity claims feed role resolution and the matrix above; the context claims, such as the Enrollment, feed the use-case context gate.
+**Enforcement topology.** The model defines policy as facts and rules: claims, prerequisites, the matrix, the context gate. Where those rules are enforced, and how the evidence reaches the enforcer, is a deployment choice the model leaves open. The principle: a fact must surface as a wire claim exactly when the evaluating party cannot observe it directly. The consequences (why the two delegations behave differently, when evidence should bind, what the OAuth wire can and cannot carry) are worked out in the design notes, after the evaluation flow.
 
-#### Layer 3: OAuth wire artefacts
+#### Layer 3: Realisation and OAuth wire
+
+Layer 3 realises the transaction in FHIR and OAuth. Its first construct is the **Operation**: a single wire-level interaction, identified as `<verb>:<artifact>:<version>` (e.g. `search:mp-MedicationAgreement:1`). Operations are reusable building blocks: the same operation can realise transactions in different use cases. One transaction is realised by one or more operations, and each operation targets one FHIR resource type, which is what SMART on FHIR scopes are minted from. The construct is not new: the [AORTA-on-FHIR interactietabel](https://aorta-on-fhir.public.vzvz.nl/aorta-on-fhir-specificaties/Working-version/aorta-interactietabel) defines the same thing as its `interactionId`, including the reuse across use cases (one operation row carrying a list of context codes); this proposal adopts that shape.
 
 {% include authorization-model-layer3.svg %}
 
-Layer 1 entities (`Transactie`, `Operation`, `FHIRResource`) appear in yellow; layer 2 entities (`IdentityClaim`, `ServiceProvider`) appear in blue. Layer-3 entities are shown in green.
+The layer-1 entity (`Transaction`) appears in yellow; layer-2 entities (`IdentityClaim`, `ServiceProvider`) appear in blue. Layer-3 entities, including the `Operation` and `FHIRResource`, are shown in green.
 
-- **AccessTokenRequest**: what the ServiceProvider sends to the AS. Carries one transactie scope token (the `tx`), an optional list of operations (interactie-ids) that narrow the minted scopes, the asserted identity claims, and the context claims.
-- **AccessToken**: the OAuth 2.0 artefact returned on success. Authorizes exactly one transactie, carries the verified identity claims, and carries the minted SMART on FHIR scopes.
-- **SoFScope**: a [SMART on FHIR v2](https://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html) scope (`<context>/<Resource>.<crud>`). The unit of resource-server enforcement, minted at issue time from the requested operations via the Zib and FHIRResource chain.
+- **AccessTokenRequest**: what the ServiceProvider sends to the AS. Carries one transaction scope token (the `tx`), an optional list of operations (interactie-ids) that narrow the minted scopes, the asserted identity claims, and the context claims. The `patient` attribute carries the data-subject BSN where the transaction concerns a patient; the AS enforces that the patient identifier in the eventual query equals the issued token's `patient` scope.
+- **AccessToken**: the OAuth 2.0 artefact returned on success. Authorizes exactly one transaction, carries the verified identity claims, and carries the minted SMART on FHIR scopes.
+- **SoFScope**: a [SMART on FHIR v2](https://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context.html) scope (`<context>/<Resource>.<crud>`). The unit of resource-server enforcement, minted at issue time from the requested operations via the profile and FHIR resource type.
 
-Note the asymmetry between request and response: the **request carries the transactie token** (optionally narrowed by interactie-ids), the **response carries the transactie token plus the minted SMART on FHIR scopes**. The AS converts requested operations into scopes at mint time.
+Note the asymmetry between request and response: the **request carries the transaction token** (optionally narrowed by interactie-ids), the **response carries the transaction token plus the minted SMART on FHIR scopes**. The AS converts requested operations into scopes at mint time.
 
-An AT is scoped to one transactie, which uses one systeemrol; the AS verifies that systeemrol is qualified and delegated. Operations in the request only narrow the minted scopes.
+An AT is scoped to one transaction. The AS verifies that a resolved QualifiedSystemRole (backed by the Qualification and the ServiceProvider delegation) covers the transaction. Operations in the request only narrow the minted scopes. Why the transaction, and not the use case or the operation, is the scope unit is argued in the design notes.
 
-#### Why the transactie is the scope unit
+Two mappings make this work, and both live in a realisation catalogue published alongside the trust framework's registry:
 
-- The *transactie* is the grain at which the PermissionMatrix decides: each cell maps `(AuthorizationRole, Transactie)` to allow or deny. Scoping the AT to one transactie aligns the wire with the decision, the AS reads the transactie, resolves the role, and looks up one cell.
-- The prerequisites are per transactie: which conditions must hold (the role resolution, the systeemrol qualification, the delegation, the context check) are set by the transactie. Bundling several transacties into one AT would mean satisfying the union of their prerequisites, which is awkward to express and can even conflict.
-- A *use case* is therefore too coarse for the AT scope: one AT would span many transacties with differing prerequisites, and an operation shared between them could not be attributed to a single cell. The use case is only a catalogue grouping of transacties, not a key the matrix or the AT needs, and it does not appear on the wire.
-- An *operation* is too fine: it is a wire-level interactie-id used for least-privilege scope minting, below the grain at which permission is decided.
-- An AT covers one activity the requester performs (one transactie, e.g. `raadplegen verstrekkingsverzoek`). A request that needs several transacties at once (a full medication overview for one patient) is served by an overview transactie such as Medicatieoverzicht, itself one transactie, or by issuing several ATs.
+- transaction to operations: which operations realise which transaction. The AS uses it to validate requested operations (REQ-4).
+- operation to scope: operation to profile to FHIR resource type to SMART on FHIR scope. The AS uses it at mint time.
 
-### Problem
-
-Each trust framework today carries its own authorization model. The models overlap conceptually but never align, which makes cross-framework integration disproportionately expensive. The same patterns appear in different vocabularies at different layers:
-
-- **Qualification**: TKID in AORTA, DVA/DVP in MedMij, similar mechanisms in Twiin. All express "this product may act in this technical role", but with different names, registries, and APIs.
-- **Delegation chain**: AORTA, MedMij, and Twiin each construct delegation chains between professionals, organisations, and service providers differently. The chain shape is usually similar; the credentials and granularities are not.
-- **Scope on the OAuth wire**: each framework has a different convention for how the authorized work is identified in a request and on the issued token.
-
-| Trust framework | What identifies the authorized work in the request scope | Survives onto issued AT? |
-|---|---|---|
-| AORTA professional (read) | implicit, derived from `(aorta.systeemrol.X, aorta.contextcode.Y)` | absent |
-| AORTA professional (write) | partially explicit, via `transaction:mp-X-Bundle:V` | partially preserved |
-| MedMij | explicit, tilde-attached `~medmij.gegevensdienst.<n>` | preserved |
-| Twiin | explicit, `twiin.gegevensdienst.<id>` | preserved |
-| Nuts use-case communities | varies per working group | varies |
-{:.grid .table-hover}
-
-Concrete consequences:
-
-1. **Implicit identification (AORTA read)**: the AS reconstructs intent from a pair of scope tokens. This is fragile to catalogue evolution and pushes semantic work into the AS.
-2. **Asymmetric AT contents**: MedMij carries the identifier on the issued AT, AORTA professional does not. Resource servers cannot uniformly audit by use case.
-3. **Inconsistent grammar across the wire**: verb-style, tilde-attached, category-style. Three vocabularies for the same semantic concept.
-4. **Composability is undefined**: what does a request with five interactie-ids mean? All required, any acceptable, an intersection? Each AS invents an answer.
-5. **Cross-framework reasoning is hard**: a developer writing a system that participates in two frameworks needs to learn two complete models and the unstated mapping between them.
+The catalogue is owned by whoever realises the information standard for the framework. Today it exists per framework, the interactietabel being one realisation. The model requires only that it is published and that the AS resolves both mappings by lookup, not derivation.
 
 ### Specification
 
-The Problem section above sets out what the convention has to address. The subsections below state the normative rules. Cumulatively, they require a shared layer-2 model, a uniform transactie identifier format on the OAuth wire, a single transactie per request with the identifier preserved on the issued AT, and policy lookup by direct identifier match rather than derivation. The model is independent of how identity claims are attested.
+The subsections below state the normative rules. Cumulatively, they require the shared layer-2 model, a uniform transaction identifier format on the OAuth wire, a single transaction per request with the identifier preserved on the issued AT, and policy lookup by direct identifier match rather than derivation. The model is independent of how identity claims are attested.
+
+The rules bind a trust framework that adopts this model; adoption itself is voluntary and per framework. They are written as conformance requirements so that adoption is testable, not because any framework is bound today. The Adoption section below sketches what adopting costs.
+
+The rules come in two kinds. The model rules (the bullet list in the next subsection) bind the trust framework's registry content: how qualifications, prerequisites, and the matrix are expressed. The numbered requirements (REQ-1 through REQ-10, further down) bind runtime behaviour on the wire: what an AT request must contain, what an issued AT must carry, and what the AS must verify. The REQ identifiers exist because these rules are individually testable; implementations and test suites reference them by number.
 
 #### Authorization information model
 
 The normative model for layers 2 and 3 is the one shown in the Layer 2 and Layer 3 diagrams above. Implementations SHALL preserve the entity meanings as described in those subsections. Specifically:
 
-- A ServiceProvider's Qualifications SHALL be expressed per systeemrol.
-- A HealthcareProfessional-to-HealthcareOrganization delegation SHALL be expressed per bedrijfsrol.
-- A ServiceProvider delegation SHALL be expressed per systeemrol.
-- A RolePrerequisite SHALL resolve presented identity claims to an AuthorizationRole, which refines exactly one Bedrijfsrol; a role MAY have several RolePrerequisites, and satisfying any one is sufficient.
-- A SysteemrolPrerequisite SHALL resolve a ServiceProvider's claims to a Systeemrol.
-- The PermissionMatrix SHALL map (AuthorizationRole, Transactie) to allow or deny plus a delegatable flag.
-- An AccessTokenRequest SHALL be scoped to exactly one Transactie and MAY narrow to a subset of that transactie's operations.
-- An AccessToken SHALL authorize exactly one Transactie.
+- A ServiceProvider's Qualifications SHALL be expressed per system role.
+- A HealthcareProfessional-to-HealthcareOrganization delegation SHALL be expressed per business role.
+- A ServiceProvider delegation SHALL be expressed per system role.
+- A RolePrerequisite SHALL resolve presented identity claims to an AuthorizationRole, which refines exactly one business role; a role MAY have several RolePrerequisites, and satisfying any one is sufficient.
+- A SystemRolePrerequisite SHALL resolve a ServiceProvider's claims to a QualifiedSystemRole. A QualifiedSystemRole refines exactly one system role and covers one or more of the transactions that use that system role. Absent an explicit refinement, the QualifiedSystemRole SHALL default to the system role itself, covering all of that system role's transactions.
+- Every trust framework SHALL publish a PermissionMatrix per use case, mapping (AuthorizationRole, Transaction) to allow or deny plus a delegatable flag. The matrix MAY be trivial (an explicit allow for every resolved AuthorizationRole), but SHALL NOT be absent; the absence of an entry SHALL be treated as deny.
+- A trust framework MAY require a Membership claim (organisational admission to the framework or an information standard) for the HealthcareOrganization; prerequisites reference it like any other identity claim.
+- An AccessTokenRequest SHALL be scoped to exactly one Transaction and MAY narrow to a subset of the operations that realise that transaction.
+- An AccessToken SHALL authorize exactly one Transaction.
 
 Trust frameworks MAY use additional concepts beyond these (framework-specific governance entities, for example), but SHALL NOT redefine the meaning of the concepts above.
 
-#### Transactie scope token
+#### Transaction scope token
 
-Every AT request defines exactly one transactie scope token with the format:
+Every AT request defines exactly one transaction scope token with the format:
 
 ```
-<governance-body>.tx.<information-standard>.<transactie>.<version>
+<governance-body>.tx.<information-standard>.<transaction>.<version>
 ```
 
 Examples:
@@ -154,16 +175,247 @@ medmij.tx.medicatie.medicatieafspraak-raadplegen.1-0
 Segment rules:
 
 - `<governance-body>`: the body governing the namespace (`aorta`, `medmij`, `twiin`, `nuts`, ...).
-- `tx`: literal marker, identifying the token as a transactie scope token.
-- `<information-standard>`: the informatiestandaard slug within the governance body (`mp` for Medicatieproces, `bgz`, `eoverdracht`, ...).
-- `<transactie>`: kebab-case transactie identifier (e.g. `verstrekkingsverzoek-raadplegen`).
+- `tx`: literal marker, identifying the token as a transaction scope token.
+- `<information-standard>`: the information-standard slug within the governance body (`mp` for Medicatieproces, `bgz`, `eoverdracht`, ...).
+- `<transaction>`: kebab-case transaction identifier (e.g. `verstrekkingsverzoek-raadplegen`).
 - `<version>`: hyphen-separated semantic version (`3-0-0`), or a single integer for major-only versioning (`3`). No `v` prefix, to match the operation token format below.
 
-The use case the transactie belongs to is derivable from the catalogue and is not carried on the wire.
+The use case the transaction belongs to is derivable from the catalogue and is not carried on the wire.
 
 #### Operation token format
 
-Operations are the fine-grained interactie-ids that MAY appear in the request scope alongside the transactie token, to narrow the scopes minted from it for least-privilege; each must belong to the scoped transactie, and omitting them requests all of the transactie's operations. The format is defined by the [AORTA-on-FHIR interactietabel](https://aorta-on-fhir.public.vzvz.nl/aorta-on-fhir-specificaties/Working-version/aorta-interactietabel). Two shapes exist:
+Operations are the fine-grained interactie-ids that MAY appear in the request scope alongside the transaction token, to narrow the scopes minted from it for least-privilege. Each must belong to the scoped transaction's realisation (the AS verifies this at mint time), and omitting them requests all of the transaction's operations. The general shape is `<verb>:<artifact>:<version>` (e.g. `search:mp-MedicationAgreement:1`); the exact format is information-standard-specific and registered in the realisation catalogue. The segment rules and the registered prefixes are listed in the [appendix](#appendix-operation-token-format-details).
+
+#### Scope tokens are opaque identifiers
+
+For the purpose of policy matching, both the transaction token and the operation tokens are treated as opaque strings: the AS looks them up in the trust framework's catalogue of registered transactions and operations, and matches against the policy by exact-string comparison. The format conventions are human-readable structure, not parsing requirements. Telling the two token kinds apart (REQ-1, REQ-3) needs only a shape check: the transaction token is dot-separated with a `tx` marker; operation tokens are colon-separated with a verb prefix.
+
+#### Conformance: AT request
+
+> **REQ-1 (SHALL).** An AT request SHALL contain exactly one transaction scope token.
+>
+> **REQ-2 (SHALL).** The AS SHALL reject the request if REQ-1 is violated (zero or more than one token).
+>
+> **REQ-3 (MAY).** The request scope MAY contain operation tokens (interactie-ids), each one belonging to the scoped transaction's realisation, to narrow the minted scopes for least-privilege.
+>
+> **REQ-4 (SHALL).** The AS SHALL reject any operation token that does not belong to the scoped transaction's realisation.
+
+#### Conformance: issued AT
+
+> **REQ-5 (SHALL).** The transaction scope token SHALL appear in the AT's `scope` alongside the minted SMART on FHIR scopes. The `scope` member is standard in both JWT access tokens and introspection responses, so the transaction identifier is visible to the resource server and the audit subsystem without any non-standard field.
+>
+> **REQ-6 (MAY).** The AT MAY additionally carry the transaction token as a dedicated `tx` claim, for consumers that prefer not to parse `scope`; when present, its value SHALL equal the token in `scope`.
+
+#### Conformance: AS behaviour
+
+> **REQ-7 (SHALL).** The AS SHALL select the applicable PermissionMatrix entry by direct match of the transaction and the resolved AuthorizationRole, not by derivation from other tokens or context.
+>
+> **REQ-8 (SHALL).** For the scoped transaction, the AS SHALL verify that:
+>
+> - the ServiceProvider's claims (its Qualification and the ServiceProvider delegation) resolve, via a SystemRolePrerequisite, to a QualifiedSystemRole whose coverage includes the scoped transaction;
+> - the presented identity claims resolve, via a RolePrerequisite, to an AuthorizationRole that the PermissionMatrix permits for the transaction;
+> - if the AuthorizationRole is exercised under mandate (defined as: the organisation acting unattended, or a user acting under the professional's responsibility), then (a) the PermissionMatrix entry SHALL be delegatable, and (b) a HealthcareProfessional-to-HealthcareOrganization delegation SHALL authorize the business role the AuthorizationRole refines;
+> - the context gate passes (consent, treatment relationship, purpose-of-use, where required).
+>
+> **REQ-9 (SHALL).** The AS SHALL reject the request if the transaction is unknown, no PermissionMatrix entry permits the resolved AuthorizationRole, or any check in REQ-8 fails.
+
+#### Identity claims, context, and verification
+
+Identity claims are the typed assertions the AS resolves into roles. For the scoped transaction the set typically includes:
+
+- The professional's identifier and rolcode, today issued under the UZI register (DEZI, its successor programme, keeps both concepts).
+- The organisation's identifier (URA) and role type.
+- The system role the transaction uses.
+- The ServiceProvider's Qualification and the two delegation credentials in the chain.
+
+In current Dutch implementations these claims appear in several forms, sometimes mixed within one request: signed claims in SAML tokens, Verifiable Credentials, JWT claims issued by a trusted Authorization Server, claims derived from an mTLS client certificate, or claims held in a registry the AS consults. The proposal works with any of these; it does not prescribe a wire format.
+
+Which claims a request must carry follows from the prerequisites: exactly those the scoped transaction's RolePrerequisite and SystemRolePrerequisite read to resolve the AuthorizationRole and the QualifiedSystemRole. There is no separate required-claims list to maintain.
+
+**Context gate.** Role resolution answers "who is the requester"; the context gate answers "is sharing this patient's data allowed". It evaluates ContextClaims about the request rather than the requester: the patient (BSN), the Enrollment (the treatment relationship), consent, and purpose-of-use. Purpose-of-use is the requester's declared purpose for the request; it is distinct from the legal basis (grondslag) that makes sharing lawful, although the declared purpose determines which legal basis must hold. The gate is attached to the use case because the claims it evaluates concern the intent, which all the use case's transactions share; attaching identical gates per transaction would only duplicate them. A trust framework MAY narrow the gate for an individual transaction, never loosen it. Because a transaction belongs to exactly one use case, the scoped transaction fixes which gate applies. The AS evaluates it alongside the PermissionMatrix (REQ-8).
+
+> **REQ-10 (SHALL).** The client SHALL present the identity claims needed to resolve the AuthorizationRole and the QualifiedSystemRole for the scoped transaction, together with the ContextClaims the applicable context gate requires (the use case's gate, possibly narrowed for the scoped transaction). The AS SHALL verify role resolution, the matrix permission, and the context gate independently, and SHALL reject the request if any required claim is absent or any check fails.
+
+### Adoption
+
+The model claims no new governance body. Each construct already exists in every framework under a local name; adoption means publishing the existing artefact in the shared vocabulary:
+
+| Existing artefact | Model construct |
+|---|---|
+| TKID (AORTA) | Qualification registry |
+| Autorisatierichtlijn medicatieveiligheid (AORTA) | PermissionMatrix |
+| AORTA-on-FHIR interactietabel | Realisation catalogue |
+| Deelnemersovereenkomst (MedMij, Twiin), aansluitvoorwaarden (AORTA) | Membership |
+| Mandaattoken (AORTA) | HCP-to-HCO delegation |
+| DVA/DVP admission (MedMij) _(draft mapping, to be verified)_ | Qualification plus Membership |
+{:.grid .table-hover}
+
+The minimal first step is the transaction scope token format alone: it requires no registry changes beyond listing the tokens, is visible on the wire, and gives audit and cross-framework tooling a uniform identifier. The full layer-2 publication can follow per framework, per information standard.
+
+Open issue: custodianship of the shared vocabulary (this chapter) once more than one framework adopts it. Candidates: Nictiz (owns layer 1), or the generieke functies programme. To be resolved with the trust framework architects.
+
+### Evaluation flow
+
+{% include authorization-model-evaluation.svg %}
+
+Happy path. Any check failure results in rejection, not shown for clarity. The legend on the diagram marks each step's input sources: **R** for the AT request, **L1** for the layer-1 catalogue, **L2** for the trust framework registry (layer 2), **L3** for the realisation catalogue (the interactietabel). Steps that depend on derived context (e.g. "the required system role per operation") inherit their source from the step that resolved that context.
+
+Because the AT is scoped to a single transaction, role resolution, the system-side coverage check, the matrix lookup, and the context gate are each evaluated once for that transaction; any operations in the request only narrow the minted scopes.
+
+### Design notes
+
+_This section is rationale, not specification: it argues the design decisions the model sections state._
+
+#### Why the transaction is the scope unit
+
+- The _transaction_ is the grain at which the PermissionMatrix decides: each cell maps `(AuthorizationRole, Transaction)` to allow or deny. Scoping the AT to one transaction aligns the wire with the decision: the AS reads the transaction, resolves the role, and looks up one cell.
+- The prerequisites are per transaction: which conditions must hold (the role resolution, the system-side coverage, the delegation, the context check) are set by the transaction. Bundling several transactions into one AT would mean satisfying the union of their prerequisites, which is awkward to express and can even conflict.
+- A _use case_ is too coarse for the AT scope: one AT would span many transactions with differing prerequisites, and an operation shared between them could not be attributed to a single cell. The use case is a catalogue grouping of transactions and the carrier of the context gate, not a key the matrix or the AT needs, and it does not appear on the wire.
+- An _operation_ is too fine: it is a wire-level interactie-id used for least-privilege scope minting, below the grain at which permission is decided. It is also reusable across transactions, so an operation alone does not identify the intent.
+- An AT covers one activity the requester performs (one transaction, e.g. `Raadplegen verstrekkingsverzoek`). A request that needs several transactions at once (a full medication overview for one patient) is served by an overview transaction such as Medicatieoverzicht, itself one transaction, or by issuing several ATs.
+
+This makes the wire chattier, and that cost is accepted deliberately. A viewer that opens the full Medicatiebouwstenen use case touches seven raadplegen transactions and therefore needs seven token requests, each a round trip to the source-side AS (the AS is usually co-located with the RS). Three things bound the cost. The requests are independent, so they can be issued in parallel. The issued AT is cacheable per (transaction, patient) within its lifetime, so the volume is per viewer session, not per screen refresh. Batching several transactions into one AT was considered and rejected. The prerequisites and the context gate are per transaction. A bundled AT must either satisfy every bundled transaction's conditions at once, which fails entirely when one gate fails (and gates can conflict: consent may cover one data category but not another), or be evaluated loosely at bundle level. Loose evaluation erodes the per-transaction granularity of consent and audit; it is exactly the implicit-scope pattern this proposal removes. How many ATs one wire exchange may mint is a layer-3 profiling choice (a framework can adopt a batching or token-exchange profile without touching the model), as long as each issued AT stays scoped to one transaction.
+
+#### Why consent, treatment relationship, and purpose are layer-2 constructs
+
+The layer-2 constructs can be derived from the transaction dataset itself. A transaction carries a selection of dataset concepts, each optionally restricted: the concept holds a baseline conformance and cardinality, and the transaction may narrow them, never loosen. The kind of concept follows the transaction's direction. A query transaction (raadplegen) carries a `QueryParameters` group of identifiers and filters, project-specific. A delivery transaction (beschikbaarstellen, sturen) carries the zib payload; zibs enter as building-block datasets the payload concepts inherit from. That transaction dataset determines exactly what layer 2 can and cannot decide on. The bridge below maps the concepts of a query transaction onto the authorization constructs they touch.
+
+{% include authorization-model-bridge.svg %}
+
+- **The patient identifier (BSN) is the data-subject join key.** It appears in the query parameters as a layer-1 concept, and layer 2 joins on it: the AS enforces that the BSN in the query equals the `patient` scope of the access token, and the context claims (consent, treatment relationship) are about that same patient. Whether a patient is involved is itself a layer-1 fact: if the transaction dataset carries no patient identifier, there is no data-subject, the `patient` attribute on the access token is absent, and the patient-bound context claims do not apply.
+- **Consent, treatment relationship, and purpose are absent from the dataset.** No dataset concept carries them. That confirms they are layer-2 constructs: ContextClaims evaluated by the trust framework, not data the transaction exchanges. The consent check is the source's responsibility, whether against a national facility (Mitz) or a local consent registration; it is not part of the requester-provided claim set, and the diagram marks it separately.
+
+Everything else in the query stays in layer 1: record-narrowing identifiers (a behandeling-id, a record-id) map to no layer-2 claim, and payload actor concepts (a record's prescriber) relate to the requester's identity claims in type only, never in instance.
+
+#### Enforcement topology and evidence
+
+The model defines policy as facts and rules; this subsection works out where those rules can be enforced and how the evidence reaches the enforcer. Both are deployment choices of the trust framework, on two axes.
+
+_Where._ The governing principle: a fact must surface as a wire claim exactly when the evaluating party cannot observe it directly. Each policy is enforced by the party that owns the duty, or by an intermediary acting for it. Three consequences:
+
+- The source owns the decision to make data available (the beschikbaarstellen slice of the matrix). It enforces that itself, or a central intermediary enforces it on its behalf. The consumer is never the enforcer of source-side policy.
+- The professional-to-organisation delegation is internal to the source: a source enforcing its own policy already knows its employment relations and mandates, and presents no credentials to itself. The mandate becomes a wire credential only under intermediary enforcement, when the intermediary cannot see inside the organisation.
+- The ServiceProvider delegation is evaluated by the counterparty of the exchange, which can never observe that relationship directly. It therefore remains evidence in every topology, as a presented credential or a trusted registry entry. Where an organisation operates its own systems, the delegation degenerates into the organisation's own identity claim, but the evidence requirement stays.
+
+_When._ Evidence can bind at three moments: at ecosystem registration (the enforcer verified the fact when the member joined), at decision time from a registry (the AS consults a store of member claims when issuing the token), or presented with the message itself. The same layer-2 facts feed all three; the binding time should match the volatility of the fact. Qualifications change rarely, so registration-time verification suffices. Delegations change more often. The treatment relationship and consent are per-patient and per-moment, so they bind at decision time.
+
+The OAuth wire is asymmetric here: the request side has a claim-carrying convention (the AccessTokenRequest), the response side has none. A topology that wants a third party to verify source-side claims at response time therefore needs a wire convention that this proposal does not define. Verifying source-side claims at registration time or at token-issuance time avoids that gap, and fails before any data is assembled.
+
+#### Delegation lifetimes: standing and session
+
+Delegation has two lifetimes, and only one of them is a layer-2 credential. The _standing_ delegations (professional to organisation, organisation to service provider) change rarely and are governed by the matrix's `delegatable` flag and the qualification regime. The _session_ delegation, an authenticated user authorizing the system to act in their name for the duration of a session, is the authentication context itself; on the OAuth wire it is the grant behind the access token, not a credential the model adds. Attended means exactly that such a session delegation from an authenticated user exists; where it does not, a standing delegation must carry the role instead.
+
+### Examples
+
+_This section is non-normative._ Each example shows the request scope, the AS decision summary, and the token introspection response ([RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662)) that the resource server or audit subsystem would receive for the issued AT. The introspection responses are illustrative and do not specify a wire format; specific identifier values are placeholders. Trust-anchored identity claims are shown abstractly; how they are proven is out of scope.
+
+#### Worked example: a GP consults a patient's medication agreements
+
+**Use case** Medicatiebouwstenen, **transaction** Raadplegen medicatieafspraak. The request scope is one transaction token plus, optionally, the operations that narrow the minted scopes:
+
+```
+aorta.tx.mp.medicatieafspraak-raadplegen.3-0-0
+search:mp-MedicationAgreement:1
+```
+
+**Layer-2 registry for this transaction**
+
+_System side, `SystemRolePrerequisite`._ The transaction's system role is `MedicatieafspraakRaadplegend`. Medicatieproces 9 cuts its system roles per transaction, so no refinement is needed: the qualification names the system role and thereby this one transaction. The check passes only when the request carries **both** a Qualification and a ServiceProvider delegation that name that system role:
+
+| SystemRolePrerequisite              | for Raadplegen medicatieafspraak                |
+| ----------------------------------- | ----------------------------------------------- |
+| resolves                            | `MedicatieafspraakRaadplegend` (no refinement)  |
+| requires Qualification              | naming `MedicatieafspraakRaadplegend`           |
+| requires ServiceProvider delegation | naming `MedicatieafspraakRaadplegend`           |
+{:.grid .table-hover}
+
+_Professional side, `RolePrerequisite`._ An `AuthorizationRole` is a business role refined by a rolcode set, and the name carries the discriminator (e.g. `MedicatieRaadplegerArts`). Each row below is one filling: the rolcodes that resolve that role. All three refine the same business role `Medicatieraadpleger`, differing only in the rolcode set:
+
+| AuthorizationRole                    | requires rolcode in                                                                                                |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `MedicatieRaadplegerArts`            | 01.015 Huisarts and the other arts rolcodes (medisch specialisten, verpleegkundig specialisten, physician assistants, per the richtlijn) |
+| `MedicatieRaadplegerApotheker`       | 17.000 Apotheker, 17.060 Ziekenhuisapotheker, 17.075 Openbaar apotheker                                            |
+| `MedicatieRaadplegerVerpleegkundige` | 30.000 Verpleegkundige                                                                                             |
+{:.grid .table-hover}
+
+Under mandate (unattended, or a user without the rolcode working under the professional's responsibility), each row additionally requires a HCP-to-HCO delegation naming business role `Medicatieraadpleger`. A professional with the required rolcode asserts the role directly.
+
+_`PermissionMatrix`_ (slice for this transaction), keyed on `(AuthorizationRole, Transaction)`:
+
+| AuthorizationRole                    | Raadplegen medicatieafspraak | delegatable (mandaattoken) |
+| ------------------------------------ | ---------------------------- | -------------------------- |
+| `MedicatieRaadplegerArts`            | allow                        | yes                        |
+| `MedicatieRaadplegerApotheker`       | allow                        | yes                        |
+| `MedicatieRaadplegerVerpleegkundige` | deny                         | -                          |
+{:.grid .table-hover}
+
+The rolcode discriminator is what lets the matrix differ per rolcode set even within one business role: here a verpleegkundige is denied, and for the sibling transaction `Beschikbaarstellen medicatieafspraak` the Autorisatierichtlijn permits artsen but not apothekers.
+
+_Context gate (on the use case)._ Medicatiebouwstenen requires, for this patient, an Enrollment (treatment relationship) and a Mitz consent that permits sharing medication data. ContextClaims: `patient` (BSN), `Enrollment`, `mitzConsent`.
+
+**AS decision.** A huisarts requests it, authenticated and in the loop (attended). Role resolution: `rolcode=01.015` is in the `MedicatieRaadplegerArts` set, so the role resolves to `MedicatieRaadplegerArts`; no delegation is involved. System side: the Qualification and the ServiceProvider delegation both name `MedicatieafspraakRaadplegend`, so the QualifiedSystemRole resolves and covers the scoped transaction. Matrix: `(MedicatieRaadplegerArts, Raadplegen medicatieafspraak)` = allow, delegatable. Context gate: treatment relationship and Mitz consent pass. The AT is issued. Had the organisation's system made this request unattended (a background refresh, say), the role would only resolve with a HCP-to-HCO delegation naming `Medicatieraadpleger`, and only because the matrix cell says `delegatable = yes`.
+
+**Issued AT (introspection).** The operation mints the SMART scope (`mp-MedicationAgreement` maps to FHIR `MedicationRequest`):
+
+```json
+{
+  "active": true,
+  "scope": "aorta.tx.mp.medicatieafspraak-raadplegen.3-0-0 patient/MedicationRequest.rs",
+  "client_id": "...gp-ehr...",
+  "sub": "uzi:00000123",
+  "patient": "bsn:999999990",
+  "token_type": "Bearer",
+  "exp": 1760000000,
+  "iat": 1759999100
+}
+```
+
+#### Same dataset, different use case: a citizen via MedMij
+
+The same medicatieafspraak fetched through a citizen's PGO is a **different transaction**, because the use case and its context gate differ: the citizen authenticates with DigiD, the role resolves to the patient rather than a professional, and there is no treatment-relationship gate. Only the operation (`search:...MedicationAgreement...`) is shared, illustrating that operations are reusable realisation blocks while transactions are use-case-bound.
+
+```
+medmij.tx.mp.medicatieafspraak-raadplegen.1-0
+```
+
+```json
+{
+  "active": true,
+  "scope": "medmij.tx.mp.medicatieafspraak-raadplegen.1-0 patient/MedicationRequest.rs",
+  "client_id": "...pgo-app...",
+  "sub": "bsn:999999990",
+  "patient": "bsn:999999990",
+  "token_type": "Bearer",
+  "exp": 1760000000,
+  "iat": 1759999100
+}
+```
+
+#### A write transaction: a voorschrijver sends a prescription
+
+```
+aorta.tx.mp.medicatievoorschrift-sturen.3-0-0
+transaction:mp-MedicationPrescriptionProcessing-Bundle:1
+```
+
+Role resolution resolves `AuthorizationRole = VoorschrijverArts` (`rolcode=01.015`; the voorschrijver is the authenticated principal, so no delegation); the system side passes on system role `VoorschriftSturend` (Qualification and ServiceProvider delegation both naming it, no refinement involved); the matrix permits `(VoorschrijverArts, Sturen medicatievoorschrift)`; the bundle operation mints write scopes.
+
+```json
+{
+  "active": true,
+  "scope": "aorta.tx.mp.medicatievoorschrift-sturen.3-0-0 patient/MedicationRequest.cu",
+  "client_id": "...gp-ehr...",
+  "sub": "uzi:00000123",
+  "patient": "bsn:999999990",
+  "token_type": "Bearer",
+  "exp": 1760000000,
+  "iat": 1759999100
+}
+```
+
+### Appendix: operation token format details
+
+The operation token format adopts the `interactionId` shape of the [AORTA-on-FHIR interactietabel](https://aorta-on-fhir.public.vzvz.nl/aorta-on-fhir-specificaties/Working-version/aorta-interactietabel). Two shapes exist:
 
 ```
 <verb>:<artifact>:<version>                       AORTA-internal style
@@ -184,211 +436,65 @@ search:MedicationStatement:1.0:request
 
 Segment rules:
 
-- `<verb>` is one of the FHIR interaction types from the closed set: `create`, `read`, `update`, `delete`, `search`, `batch`, `transaction`, `operation`. The verb determines the wire semantics: `transaction` is a FHIR `Bundle` POST with `type=transaction`, `batch` is the looser-consistency sibling, `search` is FHIR search, and so on.
+- `<verb>` is one of the FHIR interaction types from the closed set: `create`, `read`, `update`, `delete`, `search`, `batch`, `transaction`, `operation`. The verb determines the wire semantics: `transaction` is the FHIR transaction interaction (an atomic `Bundle` POST with `type=transaction`), unrelated to the Nictiz transaction of layer 1; `batch` is the looser-consistency sibling, `search` is FHIR search, and so on. Where this chapter means the verb, it writes "FHIR transaction interaction" in full.
 - `<artifact>` identifies the target. It is either a bare FHIR resource type (PHR/MedMij interactions, e.g. `MedicationStatement`) or a profile name with a programme prefix. Prefixes seen in the AORTA interactietabel:
   - `zib-` for a Zorginformatiebouwsteen profile (`zib-MedicationAgreement`, `zib-LivingSituation`)
   - `mp-` for a Medicatieproces v9 artifact (`mp-MedicationDispense`, `mp-MedicationPrescriptionProcessing-Bundle`)
   - `mp612-` for a Medicatieproces v6.12 conversion artifact
   - `twiin-` for a Twiin infrastructure artifact (`twiin-TaskNotifiedPull`)
   - `aorta-` for an AORTA infrastructure artifact (`aorta-DataReference`)
-  - The set is open-ended; new informatiestandaarden may introduce their own prefix.
-- `<version>` is the version of the interactie definition itself, not of the zib or FHIR resource. Bare integer for AORTA-internal style (`1`, `2`); dotted decimal for MedMij-facing style (`1.0`). This matches the version format of the use-case token (numeric, no `v` prefix).
+  - The set is open-ended; new information standards may introduce their own prefix.
+- `<version>` is the version of the interactie definition itself, not of the zib or FHIR resource. Bare integer for AORTA-internal style (`1`, `2`); dotted decimal for MedMij-facing style (`1.0`). This matches the version format of the transaction token (numeric, no `v` prefix).
 - `<request|response>` (MedMij style only) marks the direction of the message in a paired exchange.
 
-Each operation in a request scope must belong to the scoped transactie. The AS verifies this at mint time.
-
-The exact shape of the operation token is information-standard-specific: each informatiestandaard registers its own artifact prefixes and version conventions. New information standards are encouraged to follow the `<verb>:<artifact>:<version>` shape above for cross-framework consistency, but the proposal does not mandate it.
-
-#### Scope tokens are opaque identifiers
-
-For the purpose of policy matching, both the use-case token and the operation tokens are treated as opaque strings: the AS looks them up in the trust framework's catalogue of registered use cases and operations, and matches against the policy by exact-string comparison. The format conventions above are human-readable structure, not parsing requirements.
-
-The two formats are deliberately distinguishable at a glance (the use-case token uses dot-separation with an explicit `uc` marker; operation tokens use colon-separation with a verb prefix). An AS implementation needs to identify which tokens in a request scope are which (per REQ-1 and REQ-3), but a simple shape check is sufficient; no internal-format parsing is required for policy evaluation.
-
-#### Conformance: AT request
-
-> **REQ-1 (SHALL).** An AT request SHALL contain exactly one transactie scope token.
->
-> **REQ-2 (SHALL).** The AS SHALL reject the request if REQ-1 is violated (zero or more than one token).
->
-> **REQ-3 (MAY).** The request scope MAY contain operation tokens (interactie-ids), each one belonging to the scoped transactie, to narrow the minted scopes for least-privilege.
->
-> **REQ-4 (SHALL).** The AS SHALL reject any operation token that does not belong to the scoped transactie.
-
-#### Conformance: issued AT
-
-> **REQ-5 (SHALL).** The issued AT SHALL carry the transactie identifier as a `tx` claim, whose value equals the request's transactie scope token.
->
-> **REQ-6 (SHALL).** The transactie scope token SHALL also appear in the AT's `scope` claim alongside the minted SMART on FHIR scopes.
-
-#### Conformance: AS behaviour
-
-> **REQ-7 (SHALL).** The AS SHALL select the applicable PermissionMatrix entry by direct match of the transactie and the resolved AuthorizationRole, not by derivation from other tokens or context.
->
-> **REQ-8 (SHALL).** For the scoped transactie, the AS SHALL verify that:
->
-> - the transactie's systeemrol is qualified for the ServiceProvider (via a SysteemrolPrerequisite) and authorized by the ServiceProvider delegation;
-> - the presented identity claims resolve, via a RolePrerequisite, to an AuthorizationRole that the PermissionMatrix permits for the transactie;
-> - the HealthcareProfessional-to-HealthcareOrganization delegation authorizes the Bedrijfsrol that the AuthorizationRole refines;
-> - the context gate passes (Mitz consent, treatment relationship, purpose-of-use, where required).
->
-> **REQ-9 (SHALL).** The AS SHALL reject the request if the transactie is unknown, no PermissionMatrix entry permits the resolved AuthorizationRole, or any check in REQ-8 fails.
-
-#### Identity claims, context, and verification
-
-Identity claims are the typed assertions the AS resolves into roles. For the scoped transactie the set typically includes:
-
-- The professional's identifier (UZI) and rolcode (the DEZI-role).
-- The organisation's identifier (URA) and role type.
-- The systeemrol the transactie uses.
-- The ServiceProvider's Qualification and the two delegation credentials in the chain.
-
-In current Dutch implementations these claims appear in several forms, sometimes mixed within one request: signed claims in SAML tokens, Verifiable Credentials, JWT claims issued by a trusted Authorization Server, or claims derived from an mTLS client certificate. The proposal works with any of these; it does not prescribe a wire format.
-
-There is no separate presence profile. The claims a request must carry are exactly those the transactie's RolePrerequisite and SysteemrolPrerequisite read to resolve the AuthorizationRole and the Systeemrol. Adding a credential route means adding a prerequisite, not editing a list.
-
-**Context gate.** Role resolution answers "who is the requester"; the context gate answers "is sharing this patient's data allowed". It evaluates ContextClaims about the request rather than the requester, typically the patient (BSN), the Enrollment (the patient's treatment relationship, issued by the professional to the organisation), Mitz consent, and purpose-of-use. The gate belongs to the use case, which carries the intent; because a transactie belongs to exactly one use case, the scoped transactie fixes which context gate applies. The AS evaluates it alongside the PermissionMatrix (REQ-8).
-
-> **REQ-10 (SHALL).** The client SHALL present the identity claims needed to resolve the AuthorizationRole and the Systeemrol for the scoped transactie, together with the ContextClaims the use case's context gate requires. The AS SHALL verify role resolution, the matrix permission, and the context gate independently, and SHALL reject the request if any required claim is absent or any check fails.
-
-### Evaluation flow
-
-{% include authorization-model-evaluation.svg %}
-
-Happy path. Any check failure results in rejection, not shown for clarity. The legend on the diagram marks each step's input sources: **R** for the AT request, **L1** for the Nictiz catalogue (layer 1), **L2** for the trust framework registry (layer 2). Steps that depend on derived context (e.g. "the required systeemrol per operation") inherit their source from the step that resolved that context.
-
-Because the AT is scoped to a single transactie, role resolution, the systeemrol qualification and delegation check, the matrix lookup, and the context gate are each evaluated once for that transactie; any operations in the request only narrow the minted scopes.
-
-### Examples
-
-*This section is non-normative.* Each example shows the request scope, the AS decision summary, and the token introspection response ([RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662)) that the resource server or audit subsystem would receive for the issued AT. The introspection responses are illustrative and do not specify a wire format; specific identifier values are placeholders. Trust-anchored identity claims are shown abstractly; how they are proven is out of scope.
-
-#### Worked example: a GP consults a patient's medication agreements
-
-**Use case** Medicatiebouwstenen, **transactie** Raadplegen medicatieafspraak. The request scope is one transactie token plus, optionally, the operations that narrow the minted scopes:
-
-```
-aorta.tx.mp.medicatieafspraak-raadplegen.3-0-0
-search:mp-MedicationAgreement:1
-```
-
-**Layer-2 registry for this transactie**
-
-*System side, `SysteemrolPrerequisite`.* The transactie's systeemrol is `MedicatieafspraakRaadplegend`. It is filled only when the request carries **both** a Qualification and a ServiceProvider delegation that name that systeemrol:
-
-| resolves Systeemrol | requires Qualification (value) | and ServiceProvider delegation (value) |
-|---|---|---|
-| `MedicatieafspraakRaadplegend` | `systeemrol = MedicatieafspraakRaadplegend` | `systeemrol = MedicatieafspraakRaadplegend` |
-{:.grid .table-hover}
-
-*Professional side, `RolePrerequisite`.* An `AuthorizationRole` is a `Bedrijfsrol` refined by a rolcode set, and the name carries the discriminator (e.g. `MedicatieRaadplegerArts`). Each row below is one filling: the claims that must be present to resolve that role. All three refine the same bedrijfsrol `Medicatieraadpleger`, differing only in the rolcode set:
-
-| resolves AuthorizationRole | requires rolcode in | and HCP-to-HCO delegation (value) |
-|---|---|---|
-| `MedicatieRaadplegerArts` | `{ 01.015 Huisarts, ... (artsen, MS'en, VS'en, PA's per richtlijn) }` | `bedrijfsrol = Medicatieraadpleger` |
-| `MedicatieRaadplegerApotheker` | `{ 17.000 Apotheker, 17.060 Ziekenhuisapotheker, 17.075 Openbaar apotheker }` | `bedrijfsrol = Medicatieraadpleger` |
-| `MedicatieRaadplegerVerpleegkundige` | `{ 30.000 Verpleegkundige }` | `bedrijfsrol = Medicatieraadpleger` |
-{:.grid .table-hover}
-
-*`PermissionMatrix`* (slice for this transactie), keyed on `(AuthorizationRole, Transactie)`:
-
-| AuthorizationRole | Raadplegen medicatieafspraak | delegatable (mandaattoken) |
-|---|---|---|
-| `MedicatieRaadplegerArts` | allow | ja |
-| `MedicatieRaadplegerApotheker` | allow | ja |
-| `MedicatieRaadplegerVerpleegkundige` | deny | - |
-{:.grid .table-hover}
-
-The rolcode discriminator is what lets the matrix differ per rolcode set even within one bedrijfsrol: here a verpleegkundige is denied, and for the sibling transactie `beschikbaarstellen medicatieafspraak` the Autorisatierichtlijn permits artsen but not apothekers.
-
-*Context gate (on the use case).* Medicatiebouwstenen requires, for this patient, an Enrollment (treatment relationship) and a Mitz consent that permits sharing medication data. ContextClaims: `patient` (BSN), `Enrollment`, `mitzConsent`.
-
-**AS decision.** A huisarts requests it. Role resolution: `rolcode=01.015` is in the `MedicatieRaadplegerArts` set and the HCP-to-HCO delegation names `Medicatieraadpleger`, so the role resolves to `MedicatieRaadplegerArts`. System side: the Qualification and the ServiceProvider delegation both name `MedicatieafspraakRaadplegend`, so the systeemrol resolves. Matrix: `(MedicatieRaadplegerArts, Raadplegen medicatieafspraak)` = allow, delegatable. Context gate: treatment relationship and Mitz consent pass. The AT is issued.
-
-**Issued AT (introspection).** The operation mints the SMART scope (`mp-MedicationAgreement` maps to FHIR `MedicationRequest`):
-
-```json
-{
-  "active": true,
-  "tx": "aorta.tx.mp.medicatieafspraak-raadplegen.3-0-0",
-  "scope": "aorta.tx.mp.medicatieafspraak-raadplegen.3-0-0 patient/MedicationRequest.rs",
-  "client_id": "...gp-ehr...",
-  "sub": "uzi:00000123",
-  "patient": "bsn:999999990",
-  "token_type": "Bearer",
-  "exp": 1760000000,
-  "iat": 1759999100
-}
-```
-
-#### Same dataset, different use case: a citizen via MedMij
-
-The same medicatieafspraak fetched through a citizen's PGO is a **different transactie**, because the use case and its context gate differ: the citizen authenticates with DigiD, the role resolves to the patient rather than a professional, and there is no treatment-relationship gate. Only the operation (`search:...MedicationAgreement...`) is shared.
-
-```
-medmij.tx.mp.medicatieafspraak-raadplegen.1-0
-```
-```json
-{
-  "active": true,
-  "tx": "medmij.tx.mp.medicatieafspraak-raadplegen.1-0",
-  "scope": "medmij.tx.mp.medicatieafspraak-raadplegen.1-0 patient/MedicationRequest.rs",
-  "client_id": "...pgo-app...",
-  "sub": "bsn:999999990",
-  "patient": "bsn:999999990",
-  "token_type": "Bearer",
-  "exp": 1760000000,
-  "iat": 1759999100
-}
-```
-
-#### A write transactie: a voorschrijver sends a prescription
-
-```
-aorta.tx.mp.medicatievoorschrift-sturen.3-0-0
-transaction:mp-MedicationPrescriptionProcessing-Bundle:1
-```
-
-Role resolution resolves `AuthorizationRole = VoorschrijverArts` (`rolcode=01.015` plus the HCP-to-HCO delegation for bedrijfsrol `Voorschrijver`); the systeemrol is `VoorschriftSturend` (Qualification and ServiceProvider delegation both naming it); the matrix permits `(VoorschrijverArts, Sturen medicatievoorschrift)`; the bundle operation mints write scopes.
-
-```json
-{
-  "active": true,
-  "tx": "aorta.tx.mp.medicatievoorschrift-sturen.3-0-0",
-  "scope": "aorta.tx.mp.medicatievoorschrift-sturen.3-0-0 patient/MedicationRequest.cu",
-  "client_id": "...gp-ehr...",
-  "sub": "uzi:00000123",
-  "patient": "bsn:999999990",
-  "token_type": "Bearer",
-  "exp": 1760000000,
-  "iat": 1759999100
-}
-```
+The exact shape of the operation token is information-standard-specific: each information standard registers its own artifact prefixes and version conventions. New information standards are encouraged to follow the `<verb>:<artifact>:<version>` shape above for cross-framework consistency, but the proposal does not mandate it.
 
 ### Glossary
+
+Translation table for the layer-1 catalogue terms:
+
+| English (this chapter) | Nictiz              |
+| ---------------------- | ------------------- |
+| Information standard   | informatiestandaard |
+| Transaction group      | transactiegroep     |
+| Transaction            | transactie          |
+| Transaction dataset    | transactiedataset   |
+| System role            | systeemrol          |
+| Business role          | bedrijfsrol         |
+| Qualification          | kwalificatie        |
+{:.grid .table-hover}
 
 - **AS**: Authorization Server, mints access tokens.
 - **AT**: Access Token.
 - **AccessTokenRequest**: the OAuth 2.0 request sent by the ServiceProvider to the AS, carrying the `tx` scope token, optional operations, asserted identity claims, and context claims.
-- **AuthorizationRole**: the subject the PermissionMatrix keys on; one Nictiz Bedrijfsrol refined by a set of identity claims (typically rolcodes), resolved from presented claims by a RolePrerequisite.
-- **Bedrijfsrol**: the role a person plays in a transactie (Voorschrijver, Verstrekker, Toediener, ...). Unit of HealthcareProfessional-to-HealthcareOrganization delegation, and the role an AuthorizationRole refines.
+- **AuthorizationRole**: the subject the PermissionMatrix keys on; one business role refined by a set of identity claims (typically rolcodes), resolved from presented claims by a RolePrerequisite.
+- **Business role** (bedrijfsrol): the role a person plays in a transaction (Voorschrijver, Verstrekker, Toediener, ...). Unit of HealthcareProfessional-to-HealthcareOrganization delegation, and the role an AuthorizationRole refines.
+- **Dataset**: a tree of dataset concepts; either a primary dataset of an information standard or an imported building-block dataset (such as a zib).
+- **DatasetConcept**: one node of a dataset (a group or an item), carrying a baseline conformance and cardinality that a transaction may restrict.
+- **DEZI**: the successor programme to the UZI register for identifying healthcare professionals; it keeps the identifier and rolcode concepts. This chapter uses UZI/rolcode terminology.
 - **IdentityClaim**: a typed assertion about the requester that the policy evaluates. Carried in many wire formats (signed SAML claim, Verifiable Credential, JWT claim by a trusted AS, mTLS-derived claim, ...).
-- **ContextClaim**: a typed assertion about the request context rather than the requester (patient, Enrollment, Mitz consent, purpose-of-use), evaluated by the use case's context gate.
+- **ContextClaim**: a typed assertion about the request context rather than the requester (patient, Enrollment, consent, purpose-of-use), evaluated by the use case's context gate.
 - **Enrollment**: a ContextClaim for the patient's treatment relationship; the professional issues it to the organisation, attesting that they enrol or treat the patient.
-- **Informatiestandaard**: a Nictiz healthcare information standard (e.g. Medicatieproces, BgZ).
-- **Kwalificatie**: qualification, the upstream certification that a vendor product may act as a given systeemrol.
+- **Information standard** (informatiestandaard): a healthcare information standard (e.g. Medicatieproces, BgZ), in the Netherlands mostly maintained by Nictiz.
+- **Legal basis** (grondslag): the legal ground that makes sharing lawful (consent, treatment relationship, statutory duty). Distinct from purpose-of-use.
+- **Membership**: the claim by which a HealthcareOrganization asserts admission to a trust framework or an information standard within it; the organisational counterpart of the Qualification (deelnemersovereenkomst, aansluitvoorwaarden).
+- **Operation**: a single wire-level interaction (`<verb>:<artifact>:<version>`), the interactionId of the AORTA-on-FHIR interactietabel. A layer-3 realisation construct, reusable across transactions; not a layer-1 concept.
 - **PDP**: Policy Decision Point, see [Authorization](authorization.html).
-- **PermissionMatrix**: a layer 2 entity, per use case, mapping (AuthorizationRole, Transactie) to allow or deny plus a delegatable flag. The AORTA realisation for medication is the *Autorisatierichtlijn medicatieveiligheid*.
+- **PermissionMatrix**: a layer 2 entity, per use case, mapping (AuthorizationRole, Transaction) to allow or deny plus a delegatable flag. Always present; may be trivial (explicit allow-all); an absent entry is deny. The AORTA realisation for medication is the _Autorisatierichtlijn medicatieveiligheid_.
+- **Purpose-of-use**: the requester's declared purpose for a request (treatment, emergency, ...), a ContextClaim. Distinct from the legal basis; the declared purpose determines which legal basis must hold.
+- **Qualification** (kwalificatie): the claim by which a ServiceProvider asserts that its product passed qualification for a given system role. The qualification itself is the upstream certification process.
+- **QualifiedSystemRole**: a layer 2 refinement of exactly one system role by transaction coverage, answering "which of the transactions using this system role does this qualification grant". Defaults to the system role itself, covering all its transactions. Resolved by a SystemRolePrerequisite.
 - **RolePrerequisite**: a layer 2 rule that resolves a set of identity claims to an AuthorizationRole; a role may have several, and satisfying any one is enough.
 - **RS**: Resource Server, enforces SMART on FHIR scopes on FHIR endpoints.
 - **SoF scope**: SMART on FHIR v2 scope, e.g. `patient/MedicationRequest.s`.
-- **Systeemrol**: the role a system plays in a transactie (Sturend, Ontvangend, Raadplegend, Beschikbaarstellend). Unit of qualification and of ServiceProvider delegation.
-- **SysteemrolPrerequisite**: a layer 2 rule that resolves a ServiceProvider's claims (notably its qualification) to a Systeemrol; the system-side analogue of a RolePrerequisite, with no matrix.
-- **Transactie**: a single interaction within a transactiegroep, e.g. `Raadplegen verstrekkingsverzoek` (consult) or `Beschikbaarstellen verstrekkingsverzoek` (publish). The unit the PermissionMatrix authorizes against.
-- **Transactiegroep**: a named group of related transacties, e.g. `Verstrekkingsverzoek (raadplegen/beschikbaarstellen)`.
-- **Trust framework**: an independently governed authorization regime (afsprakenstelsel).
-- **Use case**: a sub-chapter of an informatiestandaard, equal to a "scenario" in ART-DECOR. The unit of authorization in this proposal.
-- **Zib**: *zorginformatiebouwsteen*, a Dutch healthcare data model construct.
+- **System role** (systeemrol): the role a system plays in a transaction (Sturend, Ontvangend, Raadplegend, Beschikbaarstellend). Unit of qualification and of ServiceProvider delegation.
+- **SystemRolePrerequisite**: a layer 2 rule that resolves a ServiceProvider's claims (notably its Qualification and delegation) to a QualifiedSystemRole; the system-side analogue of a RolePrerequisite, with no matrix.
+- **Transaction** (transactie): a single interaction within a transaction group, e.g. `Raadplegen verstrekkingsverzoek` (the consumer queries a source) or `Beschikbaarstellen verstrekkingsverzoeken` (the source returns the requested data). The leaf functional unit of layer 1 and the unit the PermissionMatrix authorizes against; belongs to exactly one use case. Not to be confused with the FHIR transaction interaction (an atomic `Bundle` POST), which appears as a verb in operation tokens.
+- **Transaction group** (transactiegroep): a named group of related transactions, e.g. `Verstrekkingsverzoek (raadplegen/beschikbaarstellen)`.
+- **Transaction dataset** (transactiedataset): the subset of dataset concepts a transaction selects, each optionally restricted (conformance, cardinality, condition) relative to its baseline.
+- **Trust framework**: an independently governed set of agreements for data exchange (afsprakenstelsel).
+- **Use case**: a sub-chapter of an information standard. A catalogue grouping of transaction groups; defines the intent and the context gate; not carried on the wire.
+- **Zib**: _zorginformatiebouwsteen_, a Dutch healthcare data model construct, published as a building-block dataset.
 
 ### References
 
@@ -396,6 +502,7 @@ Role resolution resolves `AuthorizationRole = VoorschrijverArts` (`rolcode=01.01
 
 - [Nictiz Handleiding Wiki documentatie](https://informatiestandaarden.nictiz.nl/wiki/Handleiding_Wiki_documentatie)
 - [ART-DECOR Medicatieproces scenarios](https://decor.nictiz.nl/pub/medicatieproces/)
+- [ART-DECOR object model documentation](https://docs.art-decor.org/)
 
 **AORTA (VZVZ)**
 

--- a/input/pagecontent/authorization-model.md
+++ b/input/pagecontent/authorization-model.md
@@ -35,9 +35,9 @@ The Examples section shows every construct introduced below as a filled-in table
 
 This proposal models authorization in three layers. The layering is a modelling decision, not a given: it is chosen because the layers have different owners, change at different rates, and answer different questions. A layer groups concerns, not authors; one governance body can author artefacts in more than one layer.
 
-- **Layer 1, Information Standards** defines _what_ transactions exist and _what data_ they carry. In the Netherlands most information standards are maintained by Nictiz; this proposal adopts the Nictiz meta-model, per the [Handleiding Wiki documentatie](https://informatiestandaarden.nictiz.nl/wiki/Handleiding_Wiki_documentatie), as the layer-1 vocabulary. It catalogues information standards, use cases, transaction groups, transactions, system roles, business roles, and the datasets they operate on. The same for all trust frameworks.
-- **Layer 2, Trust Framework** specifies _who_ may perform _which_ transactions, and under what conditions: role resolution, the permission matrix, qualifications, the delegation chain, identity claims, context claims. Today these constructs are filled per framework (VZVZ, MedMij, Twiin, Nuts-toepassingen). The model does not tie them to per-framework governance: with a shared vocabulary, layer-2 policies can be lifted to national governance where that is wanted.
-- **Layer 3, Realisation and OAuth wire** specifies _how_ a transaction reaches the wire: the FHIR profiles that represent its data, the wire-level operations that carry it, and how a single authorization decision surfaces in an OAuth 2.0 exchange. The wire artefacts are the access-token request, the issued access token, and the minted SMART on FHIR scopes that the resource server enforces.
+- **Layer 1, Information Standards** (the _information layer_) defines _what_ transactions exist and _what data_ they carry. In the Netherlands most information standards are maintained by Nictiz; this proposal adopts the Nictiz meta-model, per the [Handleiding Wiki documentatie](https://informatiestandaarden.nictiz.nl/wiki/Handleiding_Wiki_documentatie), as the layer-1 vocabulary. It catalogues information standards, use cases, transaction groups, transactions, system roles, business roles, and the datasets they operate on. The same for all trust frameworks.
+- **Layer 2, Trust Framework** (the _trust layer_) specifies _who_ may perform _which_ transactions, and under what conditions: role resolution, the permission matrix, qualifications, the delegation chain, identity claims, context claims. Today these constructs are filled per framework (VZVZ, MedMij, Twiin, Nuts-toepassingen). The model does not tie them to per-framework governance: with a shared vocabulary, layer-2 policies can be lifted to national governance where that is wanted.
+- **Layer 3, Realisation and OAuth wire** (the _realisation layer_) specifies _how_ a transaction reaches the wire: the FHIR profiles that represent its data, the wire-level operations that carry it, and how a single authorization decision surfaces in an OAuth 2.0 exchange. The wire artefacts are the access-token request, the issued access token, and the minted SMART on FHIR scopes that the resource server enforces.
 
 This proposal defines a uniform model for layers 2 and 3. Layer 1 is taken as given.
 
@@ -64,9 +64,9 @@ The transaction dataset itself shows which constructs belong in layer 2; the des
 
 #### Layer 2: Trust Framework
 
-Layer 2 adds the constructs that gate access on top of the layer-1 catalogue. It is presented in two views: first the concrete actors and the credentials that carry their claims in the Dutch context, then the general mechanism that turns those claims into an access decision. In both diagrams, layer-1 catalogue entities are shown in yellow (referenced, not redefined here), trust-framework policy and actors in pale blue, and identity claims in mid-blue.
+The trust layer (L2) adds the constructs that gate access on top of the information layer (L1) catalogue. It is presented in two views: first the concrete actors and the credentials that carry their claims in the Dutch context, then the general mechanism that turns those claims into an access decision. In both diagrams, information-layer entities are shown in yellow (referenced, not redefined here), trust-layer policy and actors in pale blue, and claims in mid-blue, typed by their `<<IdentityClaim>>` or `<<ContextClaim>>` stereotype.
 
-**Actors and credentials.**
+##### Actors and credentials
 
 This view shows who the actors are, the credentials carrying the identity claims that the access decision consumes, and the context claims (such as the Enrollment) the actors produce.
 
@@ -83,17 +83,28 @@ This view shows who the actors are, the credentials carrying the identity claims
 
 The delegation chain runs at two layers: the professional-to-organisation delegation at business-role level, the service-provider delegation at system-role level. Each step delegates only what it can express; a professional is not a system, so cannot delegate a system role. The identity claims feed the role resolution below; the context claims, such as the Enrollment, feed the use-case context gate.
 
-**Role resolution and permission.**
+##### Role resolution and permission
 
 {% include authorization-model-role-resolution.svg %}
 
-Authorization is decided in two decoupled steps on the professional side. First, _role resolution_: a `RolePrerequisite` resolves the presented identity claims to an `AuthorizationRole`, one business role refined by a set of claims (typically rolcodes). A role may have several prerequisites, and satisfying any one resolves the role; adding a new way to prove the same role means adding a prerequisite, without touching the permission rules. Second, _permission_: the `PermissionMatrix` keys on the `AuthorizationRole` and the `Transaction` and yields allow or deny plus a `delegatable` flag.
+The diagram shows two pipelines. Both start from the presented claims, and both end in the same thing: permission for one transaction. The business-role pipeline resolves the acting person's role and consults a policy; the system-role pipeline is a single check. The two pipelines are evaluated independently, in no particular order.
 
-The PermissionMatrix is always present, but its content may be trivial. The AORTA realisation for medication is the _Autorisatierichtlijn medicatieveiligheid_, a table mapping (rolcode, transaction) to ja/nee. Acute Zorg and Labuitwisseling have no such policy; they attach professions directly to transactions. A standard without a policy realises the matrix as an explicitly published allow-all over its resolved roles. The matrix is never absent and an absent entry is always deny; "no policy" is expressed as a trivial matrix, not as a missing one.
+**The business-role pipeline.** A `RolePrerequisite` resolves the presented identity claims to an `AuthorizationRole`: one business role refined by a set of claims, typically rolcodes. A role may have several prerequisites; satisfying any one resolves the role. The resolved role then meets the `PermissionMatrix`, which keys on (AuthorizationRole, Transaction) and yields allow or deny plus a `delegatable` flag. A slice of the AORTA medication matrix as illustration (the worked example shows the full registry):
 
-The system side is evaluated independently of the professional side; the model implies no order between them. In the common case it is one check: the Qualification and the ServiceProvider delegation (both introduced above) must name the transaction's system role. That suffices because the transaction itself declares which system role it involves. No matrix is needed: naming the system role is naming the permitted transactions. In the diagram, both sides therefore end in an edge to the Transaction, and both edges mean the same thing: permission. The professional side mediates that permission through the matrix, because a business role carries no per-transaction verdicts; those are policy, such as the Autorisatierichtlijn.
+| AuthorizationRole                    | refines business role | Raadplegen medicatieafspraak | delegatable |
+| ------------------------------------ | --------------------- | ---------------------------- | ----------- |
+| `MedicatieRaadplegerArts`            | Medicatieraadpleger   | allow                        | yes         |
+| `MedicatieRaadplegerApotheker`       | Medicatieraadpleger   | allow                        | yes         |
+| `MedicatieRaadplegerVerpleegkundige` | Medicatieraadpleger   | deny                         | -           |
+{:.grid .table-hover}
 
-One refinement exists, for standards whose system roles are coarse. Medicatieproces 9 defines roughly fifty system roles, one per subject-activity pair (e.g. `MedicatieafspraakRaadplegend`), so naming the system role pins down a single transaction and nothing more is needed. A standard with a handful of generic system roles would grant every transaction of the role with one qualification. For that case the trust framework MAY define a `QualifiedSystemRole`: a refinement of one system role that covers only a subset of its transactions. The `SystemRolePrerequisite` then resolves the ServiceProvider's claims to that refined role. Absent a refinement, the qualification grants every transaction of the system role. The two layer-2 roles compare as follows:
+The matrix is always present; its content may be trivial. For medication, AORTA publishes the _Autorisatierichtlijn medicatieveiligheid_, a table mapping (rolcode, transaction) to ja/nee. Standards without such a policy (Acute Zorg, Labuitwisseling) publish an explicit allow-all over their resolved roles instead. An absent entry is always deny; "no policy" is a trivial matrix, never a missing one.
+
+**The system-role pipeline.** One check: the Qualification and the ServiceProvider delegation must name the transaction's system role. The transaction itself declares which system role it involves, so naming the role is naming the permitted transactions; no matrix is needed. The business-role pipeline does need one, because a business role carries no per-transaction verdicts.
+
+One refinement exists, for standards whose system roles are coarse. Medicatieproces 9 defines roughly fifty system roles, one per subject-activity pair (e.g. `MedicatieafspraakRaadplegend`): naming the role pins down a single transaction. A standard with a handful of generic system roles would grant every transaction of the role with one qualification. For that case the trust framework MAY refine: a `QualifiedSystemRole` covers a subset of one system role's transactions, and the `SystemRolePrerequisite` resolves the ServiceProvider's claims to that refined role. Without a refinement, the qualification grants every transaction of the system role.
+
+The two layer-2 roles compare as follows:
 
 |                 | AuthorizationRole                | QualifiedSystemRole                               |
 | --------------- | -------------------------------- | ------------------------------------------------- |
@@ -104,17 +115,21 @@ One refinement exists, for standards whose system roles are coarse. Medicatiepro
 | permission via  | PermissionMatrix cell            | coverage directly permits                         |
 {:.grid .table-hover}
 
-**The patient channel.** The same machinery covers the citizen. The patient is an actor whose RolePrerequisite reads the DigiD-authenticated BSN claim and resolves to an AuthorizationRole refining the business role Patiënt. The PermissionMatrix rows for that role are the framework's allow-set for patient access (in MedMij terms: the gegevensdiensten). The system side is unchanged: the PGO operator is the ServiceProvider, its Qualification is the DVP admission, and the delegation is issued by the patient rather than by an organisation. The context gate degenerates: there is no treatment relationship, and consent is inherent in requesting one's own data. What remains is the data-subject equality check: the authenticated BSN must equal the `patient` attribute. The MedMij example in the Examples section shows the resulting token.
+##### The patient channel
 
-**Enforcement topology.** The model defines policy as facts and rules: claims, prerequisites, the matrix, the context gate. Where those rules are enforced, and how the evidence reaches the enforcer, is a deployment choice the model leaves open. The principle: a fact must surface as a wire claim exactly when the evaluating party cannot observe it directly. The consequences (why the two delegations behave differently, when evidence should bind, what the OAuth wire can and cannot carry) are worked out in the design notes, after the evaluation flow.
+The same machinery covers the citizen. The patient is an actor whose RolePrerequisite reads the DigiD-authenticated BSN claim and resolves to an AuthorizationRole refining the business role Patiënt. The PermissionMatrix rows for that role are the framework's allow-set for patient access (in MedMij terms: the gegevensdiensten). The system-role pipeline is unchanged: the PGO operator is the ServiceProvider, its Qualification is the DVP admission, and the delegation is issued by the patient rather than by an organisation. The context gate degenerates: there is no treatment relationship, and consent is inherent in requesting one's own data. What remains is the data-subject equality check: the authenticated BSN must equal the `patient` attribute. The MedMij example in the Examples section shows the resulting token.
+
+##### Enforcement topology
+
+The model defines policy as facts and rules: claims, prerequisites, the matrix, the context gate. Where those rules are enforced, and how the evidence reaches the enforcer, is a deployment choice the model leaves open. The principle: a fact must surface as a wire claim exactly when the evaluating party cannot observe it directly. The consequences (why the two delegations behave differently, when evidence should bind, what the OAuth wire can and cannot carry) are worked out in the design notes, after the evaluation flow.
 
 #### Layer 3: Realisation and OAuth wire
 
-Layer 3 realises the transaction in FHIR and OAuth. Its first construct is the **Operation**: a single wire-level interaction, identified as `<verb>:<artifact>:<version>` (e.g. `search:mp-MedicationAgreement:1`). Operations are reusable building blocks: the same operation can realise transactions in different use cases. One transaction is realised by one or more operations, and each operation targets one FHIR resource type, which is what SMART on FHIR scopes are minted from. The construct is not new: the [AORTA-on-FHIR interactietabel](https://aorta-on-fhir.public.vzvz.nl/aorta-on-fhir-specificaties/Working-version/aorta-interactietabel) defines the same thing as its `interactionId`, including the reuse across use cases (one operation row carrying a list of context codes); this proposal adopts that shape.
+The realisation layer (L3) turns the transaction into FHIR and OAuth artefacts. Its first construct is the **Operation**: a single wire-level interaction, identified as `<verb>:<artifact>:<version>` (e.g. `search:mp-MedicationAgreement:1`). Operations are reusable building blocks: the same operation can realise transactions in different use cases. One transaction is realised by one or more operations, and each operation targets one FHIR resource type, which is what SMART on FHIR scopes are minted from. The construct is not new: the [AORTA-on-FHIR interactietabel](https://aorta-on-fhir.public.vzvz.nl/aorta-on-fhir-specificaties/Working-version/aorta-interactietabel) defines the same thing as its `interactionId`, including the reuse across use cases (one operation row carrying a list of context codes); this proposal adopts that shape.
 
 {% include authorization-model-layer3.svg %}
 
-The layer-1 entity (`Transaction`) appears in yellow; layer-2 entities (`IdentityClaim`, `ServiceProvider`) appear in blue. Layer-3 entities, including the `Operation` and `FHIRResource`, are shown in green.
+The information-layer entity (`Transaction`) appears in yellow; trust-layer entities (`IdentityClaim`, `ServiceProvider`) in blue; realisation-layer entities, including the `Operation` and `FHIRResource`, in green.
 
 - **AccessTokenRequest**: what the ServiceProvider sends to the AS. Carries one transaction scope token (the `tx`), an optional list of operations (interactie-ids) that narrow the minted scopes, the asserted identity claims, and the context claims. The `patient` attribute carries the data-subject BSN where the transaction concerns a patient; the AS enforces that the patient identifier in the eventual query equals the issued token's `patient` scope.
 - **AccessToken**: the OAuth 2.0 artefact returned on success. Authorizes exactly one transaction, carries the verified identity claims, and carries the minted SMART on FHIR scopes.
@@ -258,9 +273,9 @@ Open issue: custodianship of the shared vocabulary (this chapter) once more than
 
 {% include authorization-model-evaluation.svg %}
 
-Happy path. Any check failure results in rejection, not shown for clarity. The legend on the diagram marks each step's input sources: **R** for the AT request, **L1** for the layer-1 catalogue, **L2** for the trust framework registry (layer 2), **L3** for the realisation catalogue (the interactietabel). Steps that depend on derived context (e.g. "the required system role per operation") inherit their source from the step that resolved that context.
+Happy path. Any check failure results in rejection, not shown for clarity. The legend on the diagram marks each step's input sources: **R** for the AT request, **L1** for the information-layer catalogue, **L2** for the trust-layer registry, **L3** for the realisation-layer catalogue (the interactietabel). Steps that depend on derived context (e.g. "the required system role per operation") inherit their source from the step that resolved that context.
 
-Because the AT is scoped to a single transaction, role resolution, the system-side coverage check, the matrix lookup, and the context gate are each evaluated once for that transaction; any operations in the request only narrow the minted scopes.
+Because the AT is scoped to a single transaction, role resolution, the system-role coverage check, the matrix lookup, and the context gate are each evaluated once for that transaction; any operations in the request only narrow the minted scopes.
 
 ### Design notes
 
@@ -269,7 +284,7 @@ _This section is rationale, not specification: it argues the design decisions th
 #### Why the transaction is the scope unit
 
 - The _transaction_ is the grain at which the PermissionMatrix decides: each cell maps `(AuthorizationRole, Transaction)` to allow or deny. Scoping the AT to one transaction aligns the wire with the decision: the AS reads the transaction, resolves the role, and looks up one cell.
-- The prerequisites are per transaction: which conditions must hold (the role resolution, the system-side coverage, the delegation, the context check) are set by the transaction. Bundling several transactions into one AT would mean satisfying the union of their prerequisites, which is awkward to express and can even conflict.
+- The prerequisites are per transaction: which conditions must hold (the role resolution, the system-role coverage, the delegation, the context check) are set by the transaction. Bundling several transactions into one AT would mean satisfying the union of their prerequisites, which is awkward to express and can even conflict.
 - A _use case_ is too coarse for the AT scope: one AT would span many transactions with differing prerequisites, and an operation shared between them could not be attributed to a single cell. The use case is a catalogue grouping of transactions and the carrier of the context gate, not a key the matrix or the AT needs, and it does not appear on the wire.
 - An _operation_ is too fine: it is a wire-level interactie-id used for least-privilege scope minting, below the grain at which permission is decided. It is also reusable across transactions, so an operation alone does not identify the intent.
 - An AT covers one activity the requester performs (one transaction, e.g. `Raadplegen verstrekkingsverzoek`). A request that needs several transactions at once (a full medication overview for one patient) is served by an overview transaction such as Medicatieoverzicht, itself one transaction, or by issuing several ATs.
@@ -320,7 +335,7 @@ search:mp-MedicationAgreement:1
 
 **Layer-2 registry for this transaction**
 
-_System side, `SystemRolePrerequisite`._ The transaction's system role is `MedicatieafspraakRaadplegend`. Medicatieproces 9 cuts its system roles per transaction, so no refinement is needed: the qualification names the system role and thereby this one transaction. The check passes only when the request carries **both** a Qualification and a ServiceProvider delegation that name that system role:
+_System-role pipeline, `SystemRolePrerequisite`._ The transaction's system role is `MedicatieafspraakRaadplegend`. Medicatieproces 9 cuts its system roles per transaction, so no refinement is needed: the qualification names the system role and thereby this one transaction. The check passes only when the request carries **both** a Qualification and a ServiceProvider delegation that name that system role:
 
 | SystemRolePrerequisite              | for Raadplegen medicatieafspraak                |
 | ----------------------------------- | ----------------------------------------------- |
@@ -329,7 +344,7 @@ _System side, `SystemRolePrerequisite`._ The transaction's system role is `Medic
 | requires ServiceProvider delegation | naming `MedicatieafspraakRaadplegend`           |
 {:.grid .table-hover}
 
-_Professional side, `RolePrerequisite`._ An `AuthorizationRole` is a business role refined by a rolcode set, and the name carries the discriminator (e.g. `MedicatieRaadplegerArts`). Each row below is one filling: the rolcodes that resolve that role. All three refine the same business role `Medicatieraadpleger`, differing only in the rolcode set:
+_Business-role pipeline, `RolePrerequisite`._ An `AuthorizationRole` is a business role refined by a rolcode set, and the name carries the discriminator (e.g. `MedicatieRaadplegerArts`). Each row below is one filling: the rolcodes that resolve that role. All three refine the same business role `Medicatieraadpleger`, differing only in the rolcode set:
 
 | AuthorizationRole                    | requires rolcode in                                                                                                |
 | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
@@ -353,7 +368,7 @@ The rolcode discriminator is what lets the matrix differ per rolcode set even wi
 
 _Context gate (on the use case)._ Medicatiebouwstenen requires, for this patient, an Enrollment (treatment relationship) and a Mitz consent that permits sharing medication data. ContextClaims: `patient` (BSN), `Enrollment`, `mitzConsent`.
 
-**AS decision.** A huisarts requests it, authenticated and in the loop (attended). Role resolution: `rolcode=01.015` is in the `MedicatieRaadplegerArts` set, so the role resolves to `MedicatieRaadplegerArts`; no delegation is involved. System side: the Qualification and the ServiceProvider delegation both name `MedicatieafspraakRaadplegend`, so the QualifiedSystemRole resolves and covers the scoped transaction. Matrix: `(MedicatieRaadplegerArts, Raadplegen medicatieafspraak)` = allow, delegatable. Context gate: treatment relationship and Mitz consent pass. The AT is issued. Had the organisation's system made this request unattended (a background refresh, say), the role would only resolve with a HCP-to-HCO delegation naming `Medicatieraadpleger`, and only because the matrix cell says `delegatable = yes`.
+**AS decision.** A huisarts requests it, authenticated and in the loop (attended). Role resolution: `rolcode=01.015` is in the `MedicatieRaadplegerArts` set, so the role resolves to `MedicatieRaadplegerArts`; no delegation is involved. System-role pipeline: the Qualification and the ServiceProvider delegation both name `MedicatieafspraakRaadplegend`, so the QualifiedSystemRole resolves and covers the scoped transaction. Matrix: `(MedicatieRaadplegerArts, Raadplegen medicatieafspraak)` = allow, delegatable. Context gate: treatment relationship and Mitz consent pass. The AT is issued. Had the organisation's system made this request unattended (a background refresh, say), the role would only resolve with a HCP-to-HCO delegation naming `Medicatieraadpleger`, and only because the matrix cell says `delegatable = yes`.
 
 **Issued AT (introspection).** The operation mints the SMART scope (`mp-MedicationAgreement` maps to FHIR `MedicationRequest`):
 
@@ -398,7 +413,7 @@ aorta.tx.mp.medicatievoorschrift-sturen.3-0-0
 transaction:mp-MedicationPrescriptionProcessing-Bundle:1
 ```
 
-Role resolution resolves `AuthorizationRole = VoorschrijverArts` (`rolcode=01.015`; the voorschrijver is the authenticated principal, so no delegation); the system side passes on system role `VoorschriftSturend` (Qualification and ServiceProvider delegation both naming it, no refinement involved); the matrix permits `(VoorschrijverArts, Sturen medicatievoorschrift)`; the bundle operation mints write scopes.
+Role resolution resolves `AuthorizationRole = VoorschrijverArts` (`rolcode=01.015`; the voorschrijver is the authenticated principal, so no delegation); the system-role pipeline passes on system role `VoorschriftSturend` (Qualification and ServiceProvider delegation both naming it, no refinement involved); the matrix permits `(VoorschrijverArts, Sturen medicatievoorschrift)`; the bundle operation mints write scopes.
 
 ```json
 {
@@ -451,7 +466,7 @@ The exact shape of the operation token is information-standard-specific: each in
 
 ### Glossary
 
-Translation table for the layer-1 catalogue terms:
+Translation table for the information-layer (L1) catalogue terms:
 
 | English (this chapter) | Nictiz              |
 | ---------------------- | ------------------- |
@@ -475,6 +490,7 @@ Translation table for the layer-1 catalogue terms:
 - **IdentityClaim**: a typed assertion about the requester that the policy evaluates. Carried in many wire formats (signed SAML claim, Verifiable Credential, JWT claim by a trusted AS, mTLS-derived claim, ...).
 - **ContextClaim**: a typed assertion about the request context rather than the requester (patient, Enrollment, consent, purpose-of-use), evaluated by the use case's context gate.
 - **Enrollment**: a ContextClaim for the patient's treatment relationship; the professional issues it to the organisation, attesting that they enrol or treat the patient.
+- **Information layer (L1)**: the layer of the information standards; the Nictiz catalogue of use cases, transactions, roles, and datasets.
 - **Information standard** (informatiestandaard): a healthcare information standard (e.g. Medicatieproces, BgZ), in the Netherlands mostly maintained by Nictiz.
 - **Legal basis** (grondslag): the legal ground that makes sharing lawful (consent, treatment relationship, statutory duty). Distinct from purpose-of-use.
 - **Membership**: the claim by which a HealthcareOrganization asserts admission to a trust framework or an information standard within it; the organisational counterpart of the Qualification (deelnemersovereenkomst, aansluitvoorwaarden).
@@ -484,15 +500,17 @@ Translation table for the layer-1 catalogue terms:
 - **Purpose-of-use**: the requester's declared purpose for a request (treatment, emergency, ...), a ContextClaim. Distinct from the legal basis; the declared purpose determines which legal basis must hold.
 - **Qualification** (kwalificatie): the claim by which a ServiceProvider asserts that its product passed qualification for a given system role. The qualification itself is the upstream certification process.
 - **QualifiedSystemRole**: a layer 2 refinement of exactly one system role by transaction coverage, answering "which of the transactions using this system role does this qualification grant". Defaults to the system role itself, covering all its transactions. Resolved by a SystemRolePrerequisite.
+- **Realisation layer (L3)**: the layer that turns transactions into FHIR and OAuth artefacts: profiles, operations, scope tokens, access tokens.
 - **RolePrerequisite**: a layer 2 rule that resolves a set of identity claims to an AuthorizationRole; a role may have several, and satisfying any one is enough.
 - **RS**: Resource Server, enforces SMART on FHIR scopes on FHIR endpoints.
 - **SoF scope**: SMART on FHIR v2 scope, e.g. `patient/MedicationRequest.s`.
 - **System role** (systeemrol): the role a system plays in a transaction (Sturend, Ontvangend, Raadplegend, Beschikbaarstellend). Unit of qualification and of ServiceProvider delegation.
-- **SystemRolePrerequisite**: a layer 2 rule that resolves a ServiceProvider's claims (notably its Qualification and delegation) to a QualifiedSystemRole; the system-side analogue of a RolePrerequisite, with no matrix.
+- **SystemRolePrerequisite**: a layer 2 rule that resolves a ServiceProvider's claims (notably its Qualification and delegation) to a QualifiedSystemRole; the system-role counterpart of a RolePrerequisite, with no matrix.
 - **Transaction** (transactie): a single interaction within a transaction group, e.g. `Raadplegen verstrekkingsverzoek` (the consumer queries a source) or `Beschikbaarstellen verstrekkingsverzoeken` (the source returns the requested data). The leaf functional unit of layer 1 and the unit the PermissionMatrix authorizes against; belongs to exactly one use case. Not to be confused with the FHIR transaction interaction (an atomic `Bundle` POST), which appears as a verb in operation tokens.
 - **Transaction group** (transactiegroep): a named group of related transactions, e.g. `Verstrekkingsverzoek (raadplegen/beschikbaarstellen)`.
 - **Transaction dataset** (transactiedataset): the subset of dataset concepts a transaction selects, each optionally restricted (conformance, cardinality, condition) relative to its baseline.
 - **Trust framework**: an independently governed set of agreements for data exchange (afsprakenstelsel).
+- **Trust layer (L2)**: the layer of the trust-framework constructs: role resolution, the permission matrix, qualifications, delegations, identity and context claims.
 - **Use case**: a sub-chapter of an information standard. A catalogue grouping of transaction groups; defines the intent and the context gate; not carried on the wire.
 - **Zib**: _zorginformatiebouwsteen_, a Dutch healthcare data model construct, published as a building-block dataset.
 

--- a/input/pagecontent/authorization.md
+++ b/input/pagecontent/authorization.md
@@ -16,6 +16,8 @@ This guide outlines the data requirements and principles underlying the GF Autho
 - Stakeholder Responsibility: Healthcare providers are accountable for implementing correct authorization
 
 By adhering to these principles, this Implementation Guide supports consistent and secure authorization, fostering improved interoperability within the healthcare ecosystem.
+
+See [Authorization Information Model](authorization-model.html) for the proposed shared authorization model across trust frameworks, including the use-case scope convention for OAuth 2.0 access tokens. It complements the policy input data model defined below.
 <!--  for policy makers -->
 
 ### Solution overview

--- a/input/pagecontent/authorization.md
+++ b/input/pagecontent/authorization.md
@@ -17,7 +17,7 @@ This guide outlines the data requirements and principles underlying the GF Autho
 
 By adhering to these principles, this Implementation Guide supports consistent and secure authorization, fostering improved interoperability within the healthcare ecosystem.
 
-See [Authorization Information Model](authorization-model.html) for the proposed shared authorization model across trust frameworks, including the use-case scope convention for OAuth 2.0 access tokens. It complements the policy input data model defined below.
+See [Authorization Information Model](authorization-model.html) for the proposed shared authorization model across trust frameworks, including the transaction scope convention for OAuth 2.0 access tokens. That proposal moves the identity and permission checks to token issuance and partly reworks the model on this page: the policy evaluation defined below remains as a runtime enforcement point, to which a trust framework can assign context checks and state rules.
 <!--  for policy makers -->
 
 ### Solution overview

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -123,6 +123,9 @@ pages:
     extension:
         - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
           valueCode: draft
+    authorization-model.md:
+      title: Authorization Information Model
+      generation: markdown
 
   credential-catalog.md:
     title: Credential Catalog


### PR DESCRIPTION
Build: https://build.fhir.org/ig/nuts-foundation/nl-generic-functions-ig/branches/add-authorization-information-model/authorization-model.html

## Summary

- Documents the current authorization frameworks used in Dutch healthcare data exchange (AORTA, MedMij, Twiin, Nuts use-case communities) using a shared three-layer model
- From that shared model, derives a candidate consistent OAuth 2.0 scope convention at the use-case level
- Triggered by the LSP x Nuts LDN effort

Intended as a praat-plaat for review with the trust frameworks before any normative use. Kept in draft so the FHIR IG build can render the diagrams and the resulting page can be shared for discussion.

## What is in the chapter

- Three-layer information model with PlantUML diagrams: Nictiz information standards (layer 1), trust framework (layer 2), OAuth wire artefacts (layer 3)
- Entities introduced at layer 2: TrustFramework, AuthenticationProfile, AuthorizationPolicy, the delegation chain (HCP-to-HCO at bedrijfsrol level; HCO-to-ServiceProvider at systeemrol level), Qualification, IdentityClaim with concrete subtypes
- Entities at layer 3: AccessTokenRequest, AccessToken, SoFScope
- Candidate use-case scope token format: \`<governance-body>.uc.<information-standard>.<use-case>.<version>\`
- Operation token format following the AORTA-on-FHIR interactietabel: \`<verb>:<artifact>:<version>\`
- Normative REQs (REQ-1 through REQ-10) for the AT request, the issued AT, and AS behaviour
- Happy-path AS evaluation flow diagram with per-step inputs annotated (R for request inputs, L1 for Nictiz lookups, L2 for trust-framework registry)
- Worked examples for MedMij and AORTA professional flows as RFC 7662 token-introspection responses

## Test plan

- [ ] FHIR IG build succeeds and renders the page under Authorization in the left-hand TOC
- [ ] All four PlantUML diagrams render as SVG on the page
- [ ] References resolve