### PR TITLE
Specify ServiceProvider, HealthcareProvider and ServiceProviderDelegation credentials

### DIFF
--- a/input/pagecontent/credential-HealthcareProfessionalDelegationCredential.md
+++ b/input/pagecontent/credential-HealthcareProfessionalDelegationCredential.md
@@ -140,7 +140,13 @@ All fields below are scoped to `credentialSubject`.
   </tbody>
 </table>
 
-The set of valid values for `authorizationRule` and `authorizedActions` is determined by the applicable agreement framework (`afspraakstelsel`) and is yet to be decided.
+The set of valid values for `authorizationRule` and `authorizedActions` is determined by the applicable agreement framework (`afspraakstelsel`).
+
+<div class="stu-note" markdown="1">
+
+**Editorial note**: The definitive value sets for `authorizationRule` and `authorizedActions` are still to be determined.
+
+</div>
 
 #### Semantic relations
 
@@ -169,7 +175,7 @@ graph TD
 
 #### JSON-LD Context
 
-The credential uses the shared [GIS JSON-LD context](credential-jsonld-context.html).
+The credential uses the [GIS JSON-LD context](credential-jsonld-context.html).
 
 #### Example credential
 

--- a/input/pagecontent/credential-HealthcareProfessionalDelegationCredential.md
+++ b/input/pagecontent/credential-HealthcareProfessionalDelegationCredential.md
@@ -169,50 +169,7 @@ graph TD
 
 #### JSON-LD Context
 
-The credential uses the GIS JSON-LD context, which is shared across GIS credentials:
-
-```json
-{
-  "@context": {
-    "gis": "http://gis-nl.example/",
-    "schema": "http://schema.org/",
-
-    "HealthcareProvider": "gis:HealthcareProvider",
-    "HealthcareProfessional": "gis:HealthcareProfessional",
-    "HealthcareWorker": "gis:HealthcareWorker",
-    "Patient": "gis:Patient",
-    "ServiceProvider": "gis:ServiceProvider",
-
-    "Delegation": "gis:Delegation",
-    "DelegationScope": "gis:DelegationScope",
-    "PatientEnrollment": "gis:PatientEnrollment",
-
-    "Identifier": "schema:PropertyValue",
-    "identifier": {
-      "@id": "schema:identifier",
-      "@container": "@set"
-    },
-    "system": "schema:propertyID",
-    "value": "schema:value",
-    "roleCode": {
-      "@id": "gis:roleCode",
-      "@type": "http://fhir.nl/fhir/NamingSystem/uzi-rolcode"
-    },
-    "name": "schema:name",
-
-    "hasDelegation": "gis:hasDelegation",
-    "issuedTo": "gis:issuedTo",
-    "delegatedBy": "gis:delegatedBy",
-    "scope": "gis:scope",
-    "authorizationRule": "gis:authorizationRule",
-    "authorizedActions": "gis:authorizedActions",
-    "hasEnrollment": "gis:hasEnrollment",
-    "patient": "gis:patient",
-    "enrolledBy": "gis:enrolledBy",
-    "services": "gis:services"
-  }
-}
-```
+The credential uses the shared [GIS JSON-LD context](credential-jsonld-context.html).
 
 #### Example credential
 

--- a/input/pagecontent/credential-HealthcareProviderCredential.md
+++ b/input/pagecontent/credential-HealthcareProviderCredential.md
@@ -1,0 +1,237 @@
+<!--
+SPDX-FileCopyrightText: 2026 Rein Krul
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+### HealthcareProviderCredential
+
+The `HealthcareProviderCredential` proves that a healthcare provider can be uniquely identified within the agreement framework (`afspraakstelsel`) by its URA number (`UZI-register Abonneenummer`).
+It identifies the healthcare provider but carries no authorization information itself.
+
+The credential is built from the healthcare provider's UZI server certificate through the `did:x509` DID method.
+
+#### Overview
+
+**Purpose**: Assert the identity of a healthcare provider through its URA number, bound to a `did:web` subject.
+
+**Issuer**: `did:x509` of the healthcare provider, anchored in a trusted UZI server certificate. The pastype encoded in the issuer DID MUST be `S` (UZI server certificate).
+
+**Subject**: `did:web` of the healthcare provider.
+
+**Status**: draft
+
+**Data model**: [W3C Verifiable Credentials Data Model 1.1](https://www.w3.org/TR/vc-data-model-1.1/)
+
+**VC type**: `["VerifiableCredential", "HealthcareProviderCredential"]`
+
+**Proof type**: [JWT](https://www.w3.org/TR/vc-data-model-1.1/#json-web-token)
+
+**Signature algorithm**: `RS256`. RS256 is used solely for compatibility with existing UZI certificates and hardware that does not support RSASSA-PSS.
+
+**Revocation method**: certificate revocation checks (OCSP/CRL) through the `did:x509` DID resolution, and optionally [Bitstring Status List v1.0](https://www.w3.org/TR/vc-bitstring-status-list/) via the `credentialStatus` field (not currently used).
+
+**Proof of Possession**: presenter is holder: the identifier of the presenter MUST equal the credential subject identifier.
+
+**Trust anchors**: PKIoverheid intermediate CAs for UZI server certificates. The subject `did:web` MUST use a `.nl` top-level domain.
+
+#### Background
+
+This credential gives a healthcare provider a stable, semantic identity (its URA number) within the agreement framework, bound to the `did:web` the provider uses in the network. It builds directly on UZI server certificate material through the `did:x509` DID method: the URA in `credentialSubject.identifier.value` MUST correspond to the URA encoded in the issuer certificate's `san:otherName` attribute.
+
+##### Relationship to the X509Credential
+
+The [`X509Credential`](credential-X509Credential.html) is a generic credential that exposes the raw attributes of an X.509 certificate (the `subject`, `san` and `eku` DID policies) without assigning them domain semantics. The `HealthcareProviderCredential` is purpose-built: it asserts specifically the URA identifier (and optionally the name) of a healthcare provider using FHIR `NamingSystem` semantics, rather than exposing raw certificate policy fields. Both are issued from `did:x509` UZI material; a verifier that needs the typed URA claim SHOULD rely on the `HealthcareProviderCredential`.
+
+#### Attributes
+
+All fields below are scoped to `credentialSubject`.
+
+<table class="grid">
+  <thead>
+    <tr>
+      <th>Path</th>
+      <th>IRI</th>
+      <th>Card.</th>
+      <th>Description / validation</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>id</code></td>
+      <td>-</td>
+      <td>0..1</td>
+      <td><code>did:web</code> of the healthcare provider; if present, MUST equal the <code>sub</code> claim</td>
+    </tr>
+    <tr>
+      <td><code>@type</code></td>
+      <td><code>gis:HealthcareProvider</code></td>
+      <td>1</td>
+      <td>Always <code>HealthcareProvider</code></td>
+    </tr>
+    <tr>
+      <td><code>identifier.@type</code></td>
+      <td><code>schema:PropertyValue</code></td>
+      <td>1</td>
+      <td>Always <code>Identifier</code></td>
+    </tr>
+    <tr>
+      <td><code>identifier.system</code></td>
+      <td><code>schema:propertyID</code></td>
+      <td>1</td>
+      <td>Always <code>http://fhir.nl/fhir/NamingSystem/ura</code></td>
+    </tr>
+    <tr>
+      <td><code>identifier.value</code></td>
+      <td><code>schema:value</code></td>
+      <td>1</td>
+      <td>URA number of the healthcare provider; MUST correspond to the URA in the issuer certificate's <code>san:otherName</code></td>
+    </tr>
+    <tr>
+      <td><code>name</code></td>
+      <td><code>schema:name</code></td>
+      <td>0..1</td>
+      <td>Name of the healthcare provider; if present, MUST equal the issuer certificate's <code>subject:O</code></td>
+    </tr>
+  </tbody>
+</table>
+
+#### Semantic relations
+
+The credential expresses the following entity model:
+
+```mermaid
+graph TD
+    VC[HealthcareProviderCredential]
+    VC -->|issuer| ISSUER["did:x509 (UZI server certificate)"]
+    VC -->|credentialSubject| HP["HealthcareProvider"]
+    HP -->|id| HPID["did:web:huisarts-delinden.nl"]
+    HP -->|identifier| HPIDENT["Identifier"]
+    HPIDENT -->|system| HPSYS["http://fhir.nl/fhir/NamingSystem/ura"]
+    HPIDENT -->|value| HPVAL["12345678 (URA)"]
+    HP -->|name| HPNAME["Huisarts De Linden"]
+```
+
+#### JSON-LD Context
+
+The credential uses the GIS JSON-LD context, which is shared across GIS credentials:
+
+```json
+{
+  "@context": {
+    "gis": "http://gis-nl.example/",
+    "schema": "http://schema.org/",
+
+    "HealthcareProvider": "gis:HealthcareProvider",
+    "HealthcareProfessional": "gis:HealthcareProfessional",
+    "HealthcareWorker": "gis:HealthcareWorker",
+    "Patient": "gis:Patient",
+    "ServiceProvider": "gis:ServiceProvider",
+
+    "Delegation": "gis:Delegation",
+    "DelegationScope": "gis:DelegationScope",
+    "PatientEnrollment": "gis:PatientEnrollment",
+
+    "Identifier": "schema:PropertyValue",
+    "identifier": {
+      "@id": "schema:identifier",
+      "@container": "@set"
+    },
+    "system": "schema:propertyID",
+    "value": "schema:value",
+    "roleCode": {
+      "@id": "gis:roleCode",
+      "@type": "http://fhir.nl/fhir/NamingSystem/uzi-rolcode"
+    },
+    "name": "schema:name",
+
+    "hasDelegation": "gis:hasDelegation",
+    "issuedTo": "gis:issuedTo",
+    "issuedBy": "gis:issuedBy",
+    "delegatedBy": "gis:delegatedBy",
+    "scope": "gis:scope",
+    "authorizationRule": "gis:authorizationRule",
+    "authorizedActions": "gis:authorizedActions",
+    "hasEnrollment": "gis:hasEnrollment",
+    "patient": "gis:patient",
+    "enrolledBy": "gis:enrolledBy",
+    "services": "gis:services"
+  }
+}
+```
+
+#### Example credential
+
+The following is a non-normative example of a `HealthcareProviderCredential` using the [W3C Verifiable Credentials Data Model 1.1](https://www.w3.org/TR/vc-data-model-1.1/#json-web-token) JWT encoding. It asserts that the healthcare provider identified by `did:web:huisarts-delinden.nl` has URA `12345678`.
+
+JWT Header:
+
+```json
+{
+  "alg": "RS256",
+  "typ": "JWT",
+  "kid": "did:x509:0:sha256:YmFzZTY0...dHJ1c3Q=::subject:O:Huisarts%20De%20Linden::san:otherName:2.16.528.1.1007.99.2110-1-12345678-S-90000382-00.000-12345678#0",
+  "x5c": [
+    "MIIFjDCCA3SgAwIBAgIUe8Y...kortLeafCert...==",
+    "MIIFcDCCA1igAwIBAgIUa5B...kortIntermediateCert...==",
+    "MIIFZDCCAxygAwIBAgIUbGp...kortRootCert...=="
+  ],
+  "x5t#S256": "dGhpcyBpcyBhIGV4YW1wbGUgdGh1bWJwcmludA"
+}
+```
+
+JWT Payload:
+
+```json
+{
+  "iss": "did:x509:0:sha256:YmFzZTY0...dHJ1c3Q=::subject:O:Huisarts%20De%20Linden::san:otherName:2.16.528.1.1007.99.2110-1-12345678-S-90000382-00.000-12345678",
+  "sub": "did:web:huisarts-delinden.nl",
+  "jti": "urn:uuid:3e671c46-7a3b-4c1e-9b2a-4f8e6d2c1a5b",
+  "nbf": 1740000000,
+  "exp": 1786320000,
+  "vc": {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "http://gis-nl.example/"
+    ],
+    "type": [
+      "VerifiableCredential",
+      "HealthcareProviderCredential"
+    ],
+    "issuanceDate": "2025-02-20T00:00:00Z",
+    "expirationDate": "2026-08-08T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:web:huisarts-delinden.nl",
+      "@type": "HealthcareProvider",
+      "identifier": {
+        "@type": "Identifier",
+        "system": "http://fhir.nl/fhir/NamingSystem/ura",
+        "value": "12345678"
+      },
+      "name": "Huisarts De Linden"
+    }
+  }
+}
+```
+
+#### Validation
+
+In addition to the generic validation steps from the [Credential Catalog](credential-catalog.html#profile), verifiers MUST perform the following checks:
+
+1. The issuer is a `did:x509` DID anchored in a trusted PKIoverheid intermediate CA for UZI server certificates.
+2. The pastype encoded in the issuer `did:x509` MUST be `S` (UZI server certificate). Other pastypes MUST be rejected.
+3. The URA in `credentialSubject.identifier.value` MUST correspond to the URA encoded in the issuer certificate's `san:otherName`.
+4. The `name` (if present) MUST equal the issuer certificate's `subject:O`.
+5. The `sub` claim matches `credentialSubject.id` (if present).
+6. The credential time validity:
+   - `issuanceDate` is equal to or later than the certificate's `notBefore`
+   - `expirationDate` (if present) is equal to or earlier than the certificate's `notAfter`
+
+#### Example use cases
+
+- A healthcare provider establishing its organisational identity (URA) in the network, bound to its `did:web`.
+- A data holder resolving the URA number of a requesting healthcare provider to apply authorization policy.
+
+#### Trust Anchors
+
+The credential is validated against the PKIoverheid trust chain for UZI server certificates. Refer to [https://cert.pkioverheid.nl/](https://cert.pkioverheid.nl/) for the certificates.

--- a/input/pagecontent/credential-HealthcareProviderCredential.md
+++ b/input/pagecontent/credential-HealthcareProviderCredential.md
@@ -114,51 +114,7 @@ graph TD
 
 #### JSON-LD Context
 
-The credential uses the GIS JSON-LD context, which is shared across GIS credentials:
-
-```json
-{
-  "@context": {
-    "gis": "http://gis-nl.example/",
-    "schema": "http://schema.org/",
-
-    "HealthcareProvider": "gis:HealthcareProvider",
-    "HealthcareProfessional": "gis:HealthcareProfessional",
-    "HealthcareWorker": "gis:HealthcareWorker",
-    "Patient": "gis:Patient",
-    "ServiceProvider": "gis:ServiceProvider",
-
-    "Delegation": "gis:Delegation",
-    "DelegationScope": "gis:DelegationScope",
-    "PatientEnrollment": "gis:PatientEnrollment",
-
-    "Identifier": "schema:PropertyValue",
-    "identifier": {
-      "@id": "schema:identifier",
-      "@container": "@set"
-    },
-    "system": "schema:propertyID",
-    "value": "schema:value",
-    "roleCode": {
-      "@id": "gis:roleCode",
-      "@type": "http://fhir.nl/fhir/NamingSystem/uzi-rolcode"
-    },
-    "name": "schema:name",
-
-    "hasDelegation": "gis:hasDelegation",
-    "issuedTo": "gis:issuedTo",
-    "issuedBy": "gis:issuedBy",
-    "delegatedBy": "gis:delegatedBy",
-    "scope": "gis:scope",
-    "authorizationRule": "gis:authorizationRule",
-    "authorizedActions": "gis:authorizedActions",
-    "hasEnrollment": "gis:hasEnrollment",
-    "patient": "gis:patient",
-    "enrolledBy": "gis:enrolledBy",
-    "services": "gis:services"
-  }
-}
-```
+The credential uses the shared [GIS JSON-LD context](credential-jsonld-context.html).
 
 #### Example credential
 

--- a/input/pagecontent/credential-HealthcareProviderCredential.md
+++ b/input/pagecontent/credential-HealthcareProviderCredential.md
@@ -6,7 +6,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 ### HealthcareProviderCredential
 
-The `HealthcareProviderCredential` proves that a healthcare provider can be uniquely identified within the agreement framework (`afspraakstelsel`) by its URA number (`UZI-register Abonneenummer`).
+The `HealthcareProviderCredential` proves that a healthcare provider can be uniquely identified by its URA number (`UZI-register Abonneenummer`).
 It identifies the healthcare provider but carries no authorization information itself.
 
 The credential is built from the healthcare provider's UZI server certificate through the `did:x509` DID method.
@@ -105,7 +105,7 @@ graph TD
     VC[HealthcareProviderCredential]
     VC -->|issuer| ISSUER["did:x509 (UZI server certificate)"]
     VC -->|credentialSubject| HP["HealthcareProvider"]
-    HP -->|id| HPID["did:web:huisarts-delinden.nl"]
+    HP -->|id| HPID["did:web:huisarts.example.nl"]
     HP -->|identifier| HPIDENT["Identifier"]
     HPIDENT -->|system| HPSYS["http://fhir.nl/fhir/NamingSystem/ura"]
     HPIDENT -->|value| HPVAL["12345678 (URA)"]
@@ -114,11 +114,11 @@ graph TD
 
 #### JSON-LD Context
 
-The credential uses the shared [GIS JSON-LD context](credential-jsonld-context.html).
+The credential uses the [GIS JSON-LD context](credential-jsonld-context.html).
 
 #### Example credential
 
-The following is a non-normative example of a `HealthcareProviderCredential` using the [W3C Verifiable Credentials Data Model 1.1](https://www.w3.org/TR/vc-data-model-1.1/#json-web-token) JWT encoding. It asserts that the healthcare provider identified by `did:web:huisarts-delinden.nl` has URA `12345678`.
+The following is a non-normative example of a `HealthcareProviderCredential` using the [W3C Verifiable Credentials Data Model 1.1](https://www.w3.org/TR/vc-data-model-1.1/#json-web-token) JWT encoding. It asserts that the healthcare provider identified by `did:web:huisarts.example.nl` has URA `12345678`.
 
 JWT Header:
 
@@ -141,7 +141,7 @@ JWT Payload:
 ```json
 {
   "iss": "did:x509:0:sha256:YmFzZTY0...dHJ1c3Q=::subject:O:Huisarts%20De%20Linden::san:otherName:2.16.528.1.1007.99.2110-1-12345678-S-90000382-00.000-12345678",
-  "sub": "did:web:huisarts-delinden.nl",
+  "sub": "did:web:huisarts.example.nl",
   "jti": "urn:uuid:3e671c46-7a3b-4c1e-9b2a-4f8e6d2c1a5b",
   "nbf": 1740000000,
   "exp": 1786320000,
@@ -157,7 +157,7 @@ JWT Payload:
     "issuanceDate": "2025-02-20T00:00:00Z",
     "expirationDate": "2026-08-08T00:00:00Z",
     "credentialSubject": {
-      "id": "did:web:huisarts-delinden.nl",
+      "id": "did:web:huisarts.example.nl",
       "@type": "HealthcareProvider",
       "identifier": {
         "@type": "Identifier",
@@ -190,4 +190,10 @@ In addition to the generic validation steps from the [Credential Catalog](creden
 
 #### Trust Anchors
 
-The credential is validated against the PKIoverheid trust chain for UZI server certificates. Refer to [https://cert.pkioverheid.nl/](https://cert.pkioverheid.nl/) for the certificates.
+The following trust chains are used for validating the credential:
+
+- Staat der Nederlanden Private Root CA - G1
+  - Staat der Nederlanden Private Services CA - G1
+    - UZI-register Private Server CA G1
+
+Refer to [https://cert.pkioverheid.nl/](https://cert.pkioverheid.nl/) for the certificates.

--- a/input/pagecontent/credential-ServiceProviderCredential.md
+++ b/input/pagecontent/credential-ServiceProviderCredential.md
@@ -27,7 +27,7 @@ It does not assert any authority to act on behalf of a healthcare provider; that
 
 **Proof type**: [JWT](https://www.w3.org/TR/vc-data-model-1.1/#json-web-token)
 
-**Signature algorithm**: `ES256` (recommended) or `ES512`
+**Signature algorithm**: `ES256` (recommended), `ES512` or `PS256`
 
 **Revocation method**: [Bitstring Status List v1.0](https://www.w3.org/TR/vc-bitstring-status-list/) via the optional `credentialStatus` field (not currently used).
 
@@ -98,7 +98,7 @@ graph TD
 
 #### JSON-LD Context
 
-The credential uses the shared [GIS JSON-LD context](credential-jsonld-context.html).
+The credential uses the [GIS JSON-LD context](credential-jsonld-context.html).
 
 #### Example credential
 

--- a/input/pagecontent/credential-ServiceProviderCredential.md
+++ b/input/pagecontent/credential-ServiceProviderCredential.md
@@ -1,0 +1,203 @@
+<!--
+SPDX-FileCopyrightText: 2026 Rein Krul
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+### ServiceProviderCredential
+
+The `ServiceProviderCredential` proves that a service provider is authorized within the agreement framework (`afspraakstelsel`) and competent to provide one or more of its services.
+It establishes the system context of a service provider and is consumed before an access token is issued.
+
+It does not assert any authority to act on behalf of a healthcare provider; that delegation is recorded separately in the [`ServiceProviderDelegationCredential`](credential-ServiceProviderDelegationCredential.html).
+
+#### Overview
+
+**Purpose**: Assert that a service provider is authorized within the agreement framework and is competent to provide a defined set of services.
+
+**Issuer**: `did:web` of the system operator (`stelselhouder`) that governs the agreement framework.
+
+**Subject**: `did:web` of the service provider.
+
+**Status**: draft
+
+**Data model**: [W3C Verifiable Credentials Data Model 1.1](https://www.w3.org/TR/vc-data-model-1.1/)
+
+**VC type**: `["VerifiableCredential", "ServiceProviderCredential"]`
+
+**Proof type**: [JWT](https://www.w3.org/TR/vc-data-model-1.1/#json-web-token)
+
+**Signature algorithm**: `ES256` (recommended) or `ES512`
+
+**Revocation method**: [Bitstring Status List v1.0](https://www.w3.org/TR/vc-bitstring-status-list/) via the optional `credentialStatus` field (not currently used).
+
+**Proof of Possession**: presenter is holder: the identifier of the presenter MUST equal the credential subject identifier.
+
+**Trust anchors**: the system operator (`stelselhouder`) of the agreement framework. The issuer `did:web` MUST use a `.nl` top-level domain.
+
+#### Background
+
+This credential provides the application and service context of a service provider. It confirms that the service provider is authorized within the agreement framework, not that it may act on behalf of a particular healthcare provider. The authority to act on behalf of a healthcare provider is carried by the [`ServiceProviderDelegationCredential`](credential-ServiceProviderDelegationCredential.html).
+
+The set of valid values for `services` is determined by the applicable agreement framework (`afspraakstelsel`). Initially the defined services are `gbc-client` and `gbc-server`.
+
+#### Attributes
+
+All fields below are scoped to `credentialSubject`.
+
+<table class="grid">
+  <thead>
+    <tr>
+      <th>Path</th>
+      <th>IRI</th>
+      <th>Card.</th>
+      <th>Description / validation</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>id</code></td>
+      <td>-</td>
+      <td>0..1</td>
+      <td><code>did:web</code> of the service provider; if present, MUST equal the <code>sub</code> claim</td>
+    </tr>
+    <tr>
+      <td><code>@type</code></td>
+      <td><code>gis:ServiceProvider</code></td>
+      <td>1</td>
+      <td>Always <code>ServiceProvider</code></td>
+    </tr>
+    <tr>
+      <td><code>name</code></td>
+      <td><code>schema:name</code></td>
+      <td>1</td>
+      <td>Legal name of the service provider</td>
+    </tr>
+    <tr>
+      <td><code>services</code></td>
+      <td><code>gis:services</code></td>
+      <td>1..*</td>
+      <td>Services the service provider is competent to provide; initially <code>gbc-client</code> or <code>gbc-server</code></td>
+    </tr>
+  </tbody>
+</table>
+
+#### Semantic relations
+
+The credential expresses the following entity model:
+
+```mermaid
+graph TD
+    VC[ServiceProviderCredential]
+    VC -->|issuer| ISSUER["did:web (system operator)"]
+    VC -->|credentialSubject| SP["ServiceProvider"]
+    SP -->|id| SPID["did:web:dienstverlener.example.nl"]
+    SP -->|name| SPNAME["Voorbeeld Dienstverlener B.V."]
+    SP -->|services| SPSVC["[gbc-client]"]
+```
+
+#### JSON-LD Context
+
+The credential uses the GIS JSON-LD context, which is shared across GIS credentials:
+
+```json
+{
+  "@context": {
+    "gis": "http://gis-nl.example/",
+    "schema": "http://schema.org/",
+
+    "HealthcareProvider": "gis:HealthcareProvider",
+    "HealthcareProfessional": "gis:HealthcareProfessional",
+    "HealthcareWorker": "gis:HealthcareWorker",
+    "Patient": "gis:Patient",
+    "ServiceProvider": "gis:ServiceProvider",
+
+    "Delegation": "gis:Delegation",
+    "DelegationScope": "gis:DelegationScope",
+    "PatientEnrollment": "gis:PatientEnrollment",
+
+    "Identifier": "schema:PropertyValue",
+    "identifier": {
+      "@id": "schema:identifier",
+      "@container": "@set"
+    },
+    "system": "schema:propertyID",
+    "value": "schema:value",
+    "roleCode": {
+      "@id": "gis:roleCode",
+      "@type": "http://fhir.nl/fhir/NamingSystem/uzi-rolcode"
+    },
+    "name": "schema:name",
+
+    "hasDelegation": "gis:hasDelegation",
+    "issuedTo": "gis:issuedTo",
+    "issuedBy": "gis:issuedBy",
+    "delegatedBy": "gis:delegatedBy",
+    "scope": "gis:scope",
+    "authorizationRule": "gis:authorizationRule",
+    "authorizedActions": "gis:authorizedActions",
+    "hasEnrollment": "gis:hasEnrollment",
+    "patient": "gis:patient",
+    "enrolledBy": "gis:enrolledBy",
+    "services": "gis:services"
+  }
+}
+```
+
+#### Example credential
+
+The following is a non-normative example of a `ServiceProviderCredential` using the [W3C Verifiable Credentials Data Model 1.1](https://www.w3.org/TR/vc-data-model-1.1/#json-web-token) JWT encoding. It asserts that the service provider identified by `did:web:dienstverlener.example.nl` is authorized to provide the `gbc-client` service.
+
+JWT Header:
+
+```json
+{
+  "alg": "ES256",
+  "typ": "JWT",
+  "kid": "did:web:stelselhouder.example.nl#keys-1"
+}
+```
+
+JWT Payload:
+
+```json
+{
+  "iss": "did:web:stelselhouder.example.nl",
+  "sub": "did:web:dienstverlener.example.nl",
+  "jti": "urn:uuid:9f1c2e34-5a67-4b8a-91c0-123456789abc",
+  "nbf": 1740000000,
+  "exp": 1786320000,
+  "vc": {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "http://gis-nl.example/"
+    ],
+    "type": [
+      "VerifiableCredential",
+      "ServiceProviderCredential"
+    ],
+    "issuanceDate": "2025-02-20T00:00:00Z",
+    "expirationDate": "2026-08-08T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:web:dienstverlener.example.nl",
+      "@type": "ServiceProvider",
+      "name": "Voorbeeld Dienstverlener B.V.",
+      "services": ["gbc-client"]
+    }
+  }
+}
+```
+
+#### Validation
+
+In addition to the generic validation steps from the [Credential Catalog](credential-catalog.html#profile), verifiers MUST perform the following checks:
+
+1. The issuer is the `did:web` of a trusted system operator (`stelselhouder`) of the agreement framework, using a `.nl` top-level domain.
+2. The credential `type` array includes `ServiceProviderCredential`.
+3. The `services` claim contains at least one service defined by the agreement framework.
+4. The `sub` claim matches `credentialSubject.id` (if present).
+
+#### Example use cases
+
+- A service provider presenting proof that it is authorized within the agreement framework and competent to provide a service, before requesting an access token.
+- A data holder verifying that a requesting application is an authorized service provider for the `gbc-server` service.

--- a/input/pagecontent/credential-ServiceProviderCredential.md
+++ b/input/pagecontent/credential-ServiceProviderCredential.md
@@ -33,13 +33,13 @@ It does not assert any authority to act on behalf of a healthcare provider; that
 
 **Proof of Possession**: presenter is holder: the identifier of the presenter MUST equal the credential subject identifier.
 
-**Trust anchors**: the system operator (`stelselhouder`) of the agreement framework. The issuer `did:web` MUST use a `.nl` top-level domain.
+**Trust anchors**: the system operator (`stelselhouder`) of the agreement framework. Framework-specific issuer and trust requirements are defined per agreement framework; see [Agreement framework specifics](#agreement-framework-specifics).
 
 #### Background
 
 This credential provides the application and service context of a service provider. It confirms that the service provider is authorized within the agreement framework, not that it may act on behalf of a particular healthcare provider. The authority to act on behalf of a healthcare provider is carried by the [`ServiceProviderDelegationCredential`](credential-ServiceProviderDelegationCredential.html).
 
-The set of valid values for `services` is determined by the applicable agreement framework (`afspraakstelsel`). Initially the defined services are `gbc-client` and `gbc-server`.
+The set of valid values for `services` is determined by the applicable agreement framework (`afspraakstelsel`); see [Agreement framework specifics](#agreement-framework-specifics) for the AORTA service definitions.
 
 #### Attributes
 
@@ -77,7 +77,7 @@ All fields below are scoped to `credentialSubject`.
       <td><code>services</code></td>
       <td><code>gis:services</code></td>
       <td>1..*</td>
-      <td>Services the service provider is competent to provide; initially <code>gbc-client</code> or <code>gbc-server</code></td>
+      <td>Services the service provider is competent to provide, as defined by the agreement framework</td>
     </tr>
   </tbody>
 </table>
@@ -98,55 +98,11 @@ graph TD
 
 #### JSON-LD Context
 
-The credential uses the GIS JSON-LD context, which is shared across GIS credentials:
-
-```json
-{
-  "@context": {
-    "gis": "http://gis-nl.example/",
-    "schema": "http://schema.org/",
-
-    "HealthcareProvider": "gis:HealthcareProvider",
-    "HealthcareProfessional": "gis:HealthcareProfessional",
-    "HealthcareWorker": "gis:HealthcareWorker",
-    "Patient": "gis:Patient",
-    "ServiceProvider": "gis:ServiceProvider",
-
-    "Delegation": "gis:Delegation",
-    "DelegationScope": "gis:DelegationScope",
-    "PatientEnrollment": "gis:PatientEnrollment",
-
-    "Identifier": "schema:PropertyValue",
-    "identifier": {
-      "@id": "schema:identifier",
-      "@container": "@set"
-    },
-    "system": "schema:propertyID",
-    "value": "schema:value",
-    "roleCode": {
-      "@id": "gis:roleCode",
-      "@type": "http://fhir.nl/fhir/NamingSystem/uzi-rolcode"
-    },
-    "name": "schema:name",
-
-    "hasDelegation": "gis:hasDelegation",
-    "issuedTo": "gis:issuedTo",
-    "issuedBy": "gis:issuedBy",
-    "delegatedBy": "gis:delegatedBy",
-    "scope": "gis:scope",
-    "authorizationRule": "gis:authorizationRule",
-    "authorizedActions": "gis:authorizedActions",
-    "hasEnrollment": "gis:hasEnrollment",
-    "patient": "gis:patient",
-    "enrolledBy": "gis:enrolledBy",
-    "services": "gis:services"
-  }
-}
-```
+The credential uses the shared [GIS JSON-LD context](credential-jsonld-context.html).
 
 #### Example credential
 
-The following is a non-normative example of a `ServiceProviderCredential` using the [W3C Verifiable Credentials Data Model 1.1](https://www.w3.org/TR/vc-data-model-1.1/#json-web-token) JWT encoding. It asserts that the service provider identified by `did:web:dienstverlener.example.nl` is authorized to provide the `gbc-client` service.
+The following is a non-normative example of a `ServiceProviderCredential` using the [W3C Verifiable Credentials Data Model 1.1](https://www.w3.org/TR/vc-data-model-1.1/#json-web-token) JWT encoding, using values from the AORTA agreement framework (see [Agreement framework specifics](#agreement-framework-specifics)). It asserts that the service provider identified by `did:web:dienstverlener.example.nl` is authorized to provide the `gbc-client` service.
 
 JWT Header:
 
@@ -192,10 +148,23 @@ JWT Payload:
 
 In addition to the generic validation steps from the [Credential Catalog](credential-catalog.html#profile), verifiers MUST perform the following checks:
 
-1. The issuer is the `did:web` of a trusted system operator (`stelselhouder`) of the agreement framework, using a `.nl` top-level domain.
+1. The issuer is the `did:web` of a trusted system operator (`stelselhouder`) of the agreement framework. Framework-specific issuer requirements apply; see [Agreement framework specifics](#agreement-framework-specifics).
 2. The credential `type` array includes `ServiceProviderCredential`.
 3. The `services` claim contains at least one service defined by the agreement framework.
 4. The `sub` claim matches `credentialSubject.id` (if present).
+
+#### Agreement framework specifics
+
+The main specification above is agreement-framework-generic. The issuer identity and the value set for `services` are defined per agreement framework (`afspraakstelsel`).
+
+##### AORTA
+
+Within the AORTA agreement framework:
+
+- **Issuer**: the AORTA system operator (`stelselhouder`). The issuer `did:web` MUST use a `.nl` top-level domain (e.g. `did:web:stelselhouder.example.nl`).
+- **Services**: the `services` claim MUST contain one or more of the AORTA-defined services. Initially the defined services are:
+  - `gbc-client` — the service provider acts as a client requesting data.
+  - `gbc-server` — the service provider acts as a server providing data.
 
 #### Example use cases
 

--- a/input/pagecontent/credential-ServiceProviderDelegationCredential.md
+++ b/input/pagecontent/credential-ServiceProviderDelegationCredential.md
@@ -1,0 +1,264 @@
+<!--
+SPDX-FileCopyrightText: 2026 Rein Krul
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+### ServiceProviderDelegationCredential
+
+The `ServiceProviderDelegationCredential` proves that a healthcare provider authorizes a service provider to act on its behalf within a defined authorization scope.
+It records the delegation from a healthcare provider to a service provider and is consumed before an access token is issued.
+
+It confirms delegation, not system authorization; the system authorization of the service provider is carried by the [`ServiceProviderCredential`](credential-ServiceProviderCredential.html).
+
+#### Overview
+
+**Purpose**: Assert that a healthcare provider has authorized a service provider to act on its behalf, within the scope of an authorization rule from the applicable agreement framework (`afspraakstelsel`).
+
+**Issuer**: `did:web` of the healthcare provider that delegates the authority.
+
+**Subject**: `did:web` of the service provider receiving the delegation.
+
+**Status**: draft
+
+**Data model**: [W3C Verifiable Credentials Data Model 1.1](https://www.w3.org/TR/vc-data-model-1.1/)
+
+**VC type**: `["VerifiableCredential", "ServiceProviderDelegationCredential"]`
+
+**Proof type**: [JWT](https://www.w3.org/TR/vc-data-model-1.1/#json-web-token)
+
+**Signature algorithm**: `ES256` (recommended) or `ES512`
+
+**Revocation method**: [Bitstring Status List v1.0](https://www.w3.org/TR/vc-bitstring-status-list/) via the optional `credentialStatus` field (not currently used).
+
+**Proof of Possession**: presenter is holder: the identifier of the presenter MUST equal the credential subject identifier.
+
+**Trust anchors**: the issuer `did:web` MUST use a `.nl` top-level domain.
+
+#### Background
+
+This credential records that a healthcare provider has delegated a defined set of authorized actions to a service provider. It confirms the delegation, not the system authorization of the service provider, which is carried by the [`ServiceProviderCredential`](credential-ServiceProviderCredential.html).
+
+The credential names the delegating healthcare provider (`hasDelegation.issuedBy`) by its URA number. The binding between that URA number and the issuer `did:web` of the healthcare provider must be established through a [`HealthcareProviderCredential`](credential-HealthcareProviderCredential.html) presented in the same Verifiable Presentation.
+
+The set of valid values for `authorizationRule` and `authorizedActions` is determined by the applicable agreement framework (`afspraakstelsel`).
+
+#### Attributes
+
+All fields below are scoped to `credentialSubject`.
+
+<table class="grid">
+  <thead>
+    <tr>
+      <th>Path</th>
+      <th>IRI</th>
+      <th>Card.</th>
+      <th>Description / validation</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>id</code></td>
+      <td>-</td>
+      <td>0..1</td>
+      <td><code>did:web</code> of the service provider; if present, MUST equal the <code>sub</code> claim</td>
+    </tr>
+    <tr>
+      <td><code>@type</code></td>
+      <td><code>gis:ServiceProvider</code></td>
+      <td>1</td>
+      <td>Always <code>ServiceProvider</code></td>
+    </tr>
+    <tr>
+      <td><code>hasDelegation.@type</code></td>
+      <td><code>gis:Delegation</code></td>
+      <td>1</td>
+      <td>Always <code>Delegation</code></td>
+    </tr>
+    <tr>
+      <td><code>hasDelegation.issuedBy.@type</code></td>
+      <td><code>gis:HealthcareProvider</code></td>
+      <td>1</td>
+      <td>Always <code>HealthcareProvider</code></td>
+    </tr>
+    <tr>
+      <td><code>hasDelegation.issuedBy.identifier.@type</code></td>
+      <td><code>schema:PropertyValue</code></td>
+      <td>1</td>
+      <td>Always <code>Identifier</code></td>
+    </tr>
+    <tr>
+      <td><code>hasDelegation.issuedBy.identifier.system</code></td>
+      <td><code>schema:propertyID</code></td>
+      <td>1</td>
+      <td>Always <code>http://fhir.nl/fhir/NamingSystem/ura</code></td>
+    </tr>
+    <tr>
+      <td><code>hasDelegation.issuedBy.identifier.value</code></td>
+      <td><code>schema:value</code></td>
+      <td>1</td>
+      <td>URA number of the delegating healthcare provider</td>
+    </tr>
+    <tr>
+      <td><code>hasDelegation.scope.@type</code></td>
+      <td><code>gis:DelegationScope</code></td>
+      <td>1</td>
+      <td>Always <code>DelegationScope</code></td>
+    </tr>
+    <tr>
+      <td><code>hasDelegation.scope.authorizationRule</code></td>
+      <td><code>gis:authorizationRule</code></td>
+      <td>1</td>
+      <td>URI of the authorization rule under which the delegation is issued</td>
+    </tr>
+    <tr>
+      <td><code>hasDelegation.scope.authorizedActions</code></td>
+      <td><code>gis:authorizedActions</code></td>
+      <td>1..*</td>
+      <td>Authorized actions within the authorization rule</td>
+    </tr>
+  </tbody>
+</table>
+
+#### Semantic relations
+
+The credential expresses the following entity model:
+
+```mermaid
+graph TD
+    VC[ServiceProviderDelegationCredential]
+    VC -->|issuer| ISSUER["did:web (healthcare provider)"]
+    VC -->|credentialSubject| SP["ServiceProvider"]
+    SP -->|id| SPID["did:web:dienstverlener.example.nl"]
+    SP -->|hasDelegation| DEL["Delegation"]
+    DEL -->|issuedBy| HP["HealthcareProvider"]
+    HP -->|identifier| HPID["Identifier"]
+    HPID -->|system| HPSYS["http://fhir.nl/fhir/NamingSystem/ura"]
+    HPID -->|value| HPVAL["12345678 (URA)"]
+    DEL -->|scope| SCOPE["DelegationScope"]
+    SCOPE -->|authorizationRule| RULE["https://aorta.example.nl/authorizations/gtk"]
+    SCOPE -->|authorizedActions| ACTIONS["[tokenRequest, presentCredentials]"]
+```
+
+#### JSON-LD Context
+
+The credential uses the GIS JSON-LD context, which is shared across GIS credentials:
+
+```json
+{
+  "@context": {
+    "gis": "http://gis-nl.example/",
+    "schema": "http://schema.org/",
+
+    "HealthcareProvider": "gis:HealthcareProvider",
+    "HealthcareProfessional": "gis:HealthcareProfessional",
+    "HealthcareWorker": "gis:HealthcareWorker",
+    "Patient": "gis:Patient",
+    "ServiceProvider": "gis:ServiceProvider",
+
+    "Delegation": "gis:Delegation",
+    "DelegationScope": "gis:DelegationScope",
+    "PatientEnrollment": "gis:PatientEnrollment",
+
+    "Identifier": "schema:PropertyValue",
+    "identifier": {
+      "@id": "schema:identifier",
+      "@container": "@set"
+    },
+    "system": "schema:propertyID",
+    "value": "schema:value",
+    "roleCode": {
+      "@id": "gis:roleCode",
+      "@type": "http://fhir.nl/fhir/NamingSystem/uzi-rolcode"
+    },
+    "name": "schema:name",
+
+    "hasDelegation": "gis:hasDelegation",
+    "issuedTo": "gis:issuedTo",
+    "issuedBy": "gis:issuedBy",
+    "delegatedBy": "gis:delegatedBy",
+    "scope": "gis:scope",
+    "authorizationRule": "gis:authorizationRule",
+    "authorizedActions": "gis:authorizedActions",
+    "hasEnrollment": "gis:hasEnrollment",
+    "patient": "gis:patient",
+    "enrolledBy": "gis:enrolledBy",
+    "services": "gis:services"
+  }
+}
+```
+
+#### Example credential
+
+The following is a non-normative example of a `ServiceProviderDelegationCredential` using the [W3C Verifiable Credentials Data Model 1.1](https://www.w3.org/TR/vc-data-model-1.1/#json-web-token) JWT encoding. It asserts that the healthcare provider with URA `12345678` has authorized the service provider `did:web:dienstverlener.example.nl` to perform the actions `tokenRequest` and `presentCredentials`.
+
+The values used for `authorizationRule` and `authorizedActions` are placeholders; actual values are governed by the applicable agreement framework.
+
+JWT Header:
+
+```json
+{
+  "alg": "ES256",
+  "typ": "JWT",
+  "kid": "did:web:zorginstelling.example.nl#keys-1"
+}
+```
+
+JWT Payload:
+
+```json
+{
+  "iss": "did:web:zorginstelling.example.nl",
+  "sub": "did:web:dienstverlener.example.nl",
+  "jti": "urn:uuid:4c2a1f3e-9a5b-4f90-8d3e-abcdef123456",
+  "nbf": 1740000000,
+  "exp": 1786320000,
+  "vc": {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1",
+      "http://gis-nl.example/"
+    ],
+    "type": [
+      "VerifiableCredential",
+      "ServiceProviderDelegationCredential"
+    ],
+    "issuanceDate": "2025-02-20T00:00:00Z",
+    "expirationDate": "2026-08-08T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:web:dienstverlener.example.nl",
+      "@type": "ServiceProvider",
+      "hasDelegation": {
+        "@type": "Delegation",
+        "issuedBy": {
+          "@type": "HealthcareProvider",
+          "identifier": {
+            "@type": "Identifier",
+            "system": "http://fhir.nl/fhir/NamingSystem/ura",
+            "value": "12345678"
+          }
+        },
+        "scope": {
+          "@type": "DelegationScope",
+          "authorizationRule": "https://aorta.example.nl/authorizations/gtk",
+          "authorizedActions": ["tokenRequest", "presentCredentials"]
+        }
+      }
+    }
+  }
+}
+```
+
+#### Validation
+
+In addition to the generic validation steps from the [Credential Catalog](credential-catalog.html#profile), verifiers MUST perform the following checks:
+
+1. The issuer is a `did:web` DID of a healthcare provider, using a `.nl` top-level domain.
+2. The credential `type` array includes `ServiceProviderDelegationCredential`.
+3. The `sub` claim matches `credentialSubject.id` (if present).
+4. The URA in `credentialSubject.hasDelegation.issuedBy.identifier.value` identifies the delegating healthcare provider; its binding to the issuer `did:web` MUST be established through a `HealthcareProviderCredential` presented in the same Verifiable Presentation.
+5. The values for `authorizationRule` and `authorizedActions` MUST be valid within the applicable agreement framework.
+
+#### Example use cases
+
+- A healthcare provider authorizing a service provider (e.g. a software vendor) to request access tokens and present credentials on its behalf.
+- A data holder verifying that a requesting service provider holds a valid delegation from the healthcare provider whose data is being requested.

--- a/input/pagecontent/credential-ServiceProviderDelegationCredential.md
+++ b/input/pagecontent/credential-ServiceProviderDelegationCredential.md
@@ -27,13 +27,13 @@ It confirms delegation, not system authorization; the system authorization of th
 
 **Proof type**: [JWT](https://www.w3.org/TR/vc-data-model-1.1/#json-web-token)
 
-**Signature algorithm**: `ES256` (recommended) or `ES512`
+**Signature algorithm**: `ES256` (recommended), `ES512` or `PS256`
 
 **Revocation method**: [Bitstring Status List v1.0](https://www.w3.org/TR/vc-bitstring-status-list/) via the optional `credentialStatus` field (not currently used).
 
 **Proof of Possession**: presenter is holder: the identifier of the presenter MUST equal the credential subject identifier.
 
-**Trust anchors**: the issuer `did:web` MUST use a `.nl` top-level domain.
+**Trust anchors**: the healthcare provider that issues the delegation. Framework-specific issuer and trust requirements are defined per agreement framework; see [Agreement framework specifics](#agreement-framework-specifics).
 
 #### Background
 
@@ -41,7 +41,7 @@ This credential records that a healthcare provider has delegated a defined set o
 
 The credential names the delegating healthcare provider (`hasDelegation.issuedBy`) by its URA number. The binding between that URA number and the issuer `did:web` of the healthcare provider must be established through a [`HealthcareProviderCredential`](credential-HealthcareProviderCredential.html) presented in the same Verifiable Presentation.
 
-The set of valid values for `authorizationRule` and `authorizedActions` is determined by the applicable agreement framework (`afspraakstelsel`).
+The set of valid values for `authorizationRule` and `authorizedActions` is determined by the applicable agreement framework (`afspraakstelsel`); see [Agreement framework specifics](#agreement-framework-specifics) for the AORTA definitions.
 
 #### Attributes
 
@@ -142,13 +142,11 @@ graph TD
 
 #### JSON-LD Context
 
-The credential uses the shared [GIS JSON-LD context](credential-jsonld-context.html).
+The credential uses the [GIS JSON-LD context](credential-jsonld-context.html).
 
 #### Example credential
 
-The following is a non-normative example of a `ServiceProviderDelegationCredential` using the [W3C Verifiable Credentials Data Model 1.1](https://www.w3.org/TR/vc-data-model-1.1/#json-web-token) JWT encoding. It asserts that the healthcare provider with URA `12345678` has authorized the service provider `did:web:dienstverlener.example.nl` to perform the actions `tokenRequest` and `presentCredentials`.
-
-The values used for `authorizationRule` and `authorizedActions` are placeholders; actual values are governed by the applicable agreement framework.
+The following is a non-normative example of a `ServiceProviderDelegationCredential` using the [W3C Verifiable Credentials Data Model 1.1](https://www.w3.org/TR/vc-data-model-1.1/#json-web-token) JWT encoding, using values from the AORTA agreement framework (see [Agreement framework specifics](#agreement-framework-specifics)). It asserts that the healthcare provider with URA `12345678` has authorized the service provider `did:web:dienstverlener.example.nl` to perform the actions `tokenRequest` and `presentCredentials`.
 
 JWT Header:
 
@@ -208,11 +206,29 @@ JWT Payload:
 
 In addition to the generic validation steps from the [Credential Catalog](credential-catalog.html#profile), verifiers MUST perform the following checks:
 
-1. The issuer is a `did:web` DID of a healthcare provider, using a `.nl` top-level domain.
+1. The issuer is a `did:web` DID of a healthcare provider. Framework-specific issuer requirements apply; see [Agreement framework specifics](#agreement-framework-specifics).
 2. The credential `type` array includes `ServiceProviderDelegationCredential`.
 3. The `sub` claim matches `credentialSubject.id` (if present).
 4. The URA in `credentialSubject.hasDelegation.issuedBy.identifier.value` identifies the delegating healthcare provider; its binding to the issuer `did:web` MUST be established through a `HealthcareProviderCredential` presented in the same Verifiable Presentation.
 5. The values for `authorizationRule` and `authorizedActions` MUST be valid within the applicable agreement framework.
+
+#### Agreement framework specifics
+
+The main specification above is agreement-framework-generic. The issuer identity and the value sets for `authorizationRule` and `authorizedActions` are defined per agreement framework (`afspraakstelsel`).
+
+##### AORTA
+
+Within the AORTA agreement framework:
+
+- **Issuer**: the healthcare provider that delegates the authority. The issuer `did:web` MUST use a `.nl` top-level domain (e.g. `did:web:zorginstelling.example.nl`).
+- **Authorization rule**: `authorizationRule` MUST be an AORTA-defined authorization rule URI (e.g. `https://aorta.example.nl/authorizations/gtk`).
+- **Authorized actions**: `authorizedActions` MUST contain one or more AORTA-defined actions (e.g. `tokenRequest`, `presentCredentials`).
+
+<div class="stu-note" markdown="1">
+
+**Editorial note**: The definitive AORTA value sets for `authorizationRule` and `authorizedActions` are still to be determined. The values shown above and in the example are placeholders.
+
+</div>
 
 #### Example use cases
 

--- a/input/pagecontent/credential-ServiceProviderDelegationCredential.md
+++ b/input/pagecontent/credential-ServiceProviderDelegationCredential.md
@@ -142,51 +142,7 @@ graph TD
 
 #### JSON-LD Context
 
-The credential uses the GIS JSON-LD context, which is shared across GIS credentials:
-
-```json
-{
-  "@context": {
-    "gis": "http://gis-nl.example/",
-    "schema": "http://schema.org/",
-
-    "HealthcareProvider": "gis:HealthcareProvider",
-    "HealthcareProfessional": "gis:HealthcareProfessional",
-    "HealthcareWorker": "gis:HealthcareWorker",
-    "Patient": "gis:Patient",
-    "ServiceProvider": "gis:ServiceProvider",
-
-    "Delegation": "gis:Delegation",
-    "DelegationScope": "gis:DelegationScope",
-    "PatientEnrollment": "gis:PatientEnrollment",
-
-    "Identifier": "schema:PropertyValue",
-    "identifier": {
-      "@id": "schema:identifier",
-      "@container": "@set"
-    },
-    "system": "schema:propertyID",
-    "value": "schema:value",
-    "roleCode": {
-      "@id": "gis:roleCode",
-      "@type": "http://fhir.nl/fhir/NamingSystem/uzi-rolcode"
-    },
-    "name": "schema:name",
-
-    "hasDelegation": "gis:hasDelegation",
-    "issuedTo": "gis:issuedTo",
-    "issuedBy": "gis:issuedBy",
-    "delegatedBy": "gis:delegatedBy",
-    "scope": "gis:scope",
-    "authorizationRule": "gis:authorizationRule",
-    "authorizedActions": "gis:authorizedActions",
-    "hasEnrollment": "gis:hasEnrollment",
-    "patient": "gis:patient",
-    "enrolledBy": "gis:enrolledBy",
-    "services": "gis:services"
-  }
-}
-```
+The credential uses the shared [GIS JSON-LD context](credential-jsonld-context.html).
 
 #### Example credential
 

--- a/input/pagecontent/credential-catalog.md
+++ b/input/pagecontent/credential-catalog.md
@@ -32,6 +32,9 @@ This IG defined the following credential types.
 | [HealthcareProviderRoleTypeCredential](credential-HealthcareProviderRoleTypeCredential.html)             | Establishes the category or type of healthcare services a provider organization is authorized to offer.      | draft          |
 | [DeziUserCredential](credential-DeziUserCredential.html)                                                 | Wraps a Dezi "verklaring" from the OIDC UserInfo object to assert the identity of a healthcare worker and their employment relationship.  | draft          |
 | [HealthcareProfessionalDelegationCredential](credential-HealthcareProfessionalDelegationCredential.html) | Asserts that a healthcare professional has delegated a defined set of authorized actions to a healthcare provider, as the VC counterpart of the AORTA SAML mandate token. | draft          |
+| [HealthcareProviderCredential](credential-HealthcareProviderCredential.html)                             | Identifies a healthcare provider by its URA number, built from UZI server certificate material through the `did:x509` DID method. | draft          |
+| [ServiceProviderCredential](credential-ServiceProviderCredential.html)                                   | Asserts that a service provider is authorized within the agreement framework and competent to provide one or more services. | draft          |
+| [ServiceProviderDelegationCredential](credential-ServiceProviderDelegationCredential.html)               | Asserts that a healthcare provider authorizes a service provider to act on its behalf within a defined authorization scope. | draft          |
 | [X509Credential](credential-X509Credential.html)                                                         | Represents attributes from an X.509 certificate, anchored in a trusted CA through the `did:x509` DID method. | production use |
 
 ##### Credential type status

--- a/input/pagecontent/credential-jsonld-context.md
+++ b/input/pagecontent/credential-jsonld-context.md
@@ -1,0 +1,55 @@
+<!--
+SPDX-FileCopyrightText: 2026 Rein Krul
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+### GIS JSON-LD Context
+
+The GIS credentials share a single JSON-LD context, referenced from each credential's `@context`. It is defined here once so the individual credential pages do not repeat it.
+
+The context maps the terms used across the GIS credentials (`HealthcareProvider`, `ServiceProvider`, `Delegation`, `PatientEnrollment`, identifiers, delegation and enrollment relations) to the `gis:` (`http://gis-nl.example/`) and `schema:` (`http://schema.org/`) namespaces.
+
+```json
+{
+  "@context": {
+    "gis": "http://gis-nl.example/",
+    "schema": "http://schema.org/",
+
+    "HealthcareProvider": "gis:HealthcareProvider",
+    "HealthcareProfessional": "gis:HealthcareProfessional",
+    "HealthcareWorker": "gis:HealthcareWorker",
+    "Patient": "gis:Patient",
+    "ServiceProvider": "gis:ServiceProvider",
+
+    "Delegation": "gis:Delegation",
+    "DelegationScope": "gis:DelegationScope",
+    "PatientEnrollment": "gis:PatientEnrollment",
+
+    "Identifier": "schema:PropertyValue",
+    "identifier": {
+      "@id": "schema:identifier",
+      "@container": "@set"
+    },
+    "system": "schema:propertyID",
+    "value": "schema:value",
+    "roleCode": {
+      "@id": "gis:roleCode",
+      "@type": "http://fhir.nl/fhir/NamingSystem/uzi-rolcode"
+    },
+    "name": "schema:name",
+
+    "hasDelegation": "gis:hasDelegation",
+    "issuedTo": "gis:issuedTo",
+    "issuedBy": "gis:issuedBy",
+    "delegatedBy": "gis:delegatedBy",
+    "scope": "gis:scope",
+    "authorizationRule": "gis:authorizationRule",
+    "authorizedActions": "gis:authorizedActions",
+    "hasEnrollment": "gis:hasEnrollment",
+    "patient": "gis:patient",
+    "enrolledBy": "gis:enrolledBy",
+    "services": "gis:services"
+  }
+}
+```

--- a/input/pagecontent/credential-jsonld-context.md
+++ b/input/pagecontent/credential-jsonld-context.md
@@ -6,9 +6,13 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 ### GIS JSON-LD Context
 
-The GIS credentials share a single JSON-LD context, referenced from each credential's `@context`. It is defined here once so the individual credential pages do not repeat it.
+The GIS credentials use the following JSON-LD context, referenced from each credential's `@context`. It maps the terms used across the GIS credentials (`HealthcareProvider`, `ServiceProvider`, `Delegation`, `PatientEnrollment`, identifiers, delegation and enrollment relations) to the `gis:` (`http://gis-nl.example/`) and `schema:` (`http://schema.org/`) namespaces.
 
-The context maps the terms used across the GIS credentials (`HealthcareProvider`, `ServiceProvider`, `Delegation`, `PatientEnrollment`, identifiers, delegation and enrollment relations) to the `gis:` (`http://gis-nl.example/`) and `schema:` (`http://schema.org/`) namespaces.
+<div class="stu-note" markdown="1">
+
+**Editorial note**: The `gis:` namespace URL `http://gis-nl.example/` is a placeholder. The definitive context URL is still to be determined.
+
+</div>
 
 ```json
 {

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -141,6 +141,15 @@ pages:
     credential-HealthcareProfessionalDelegationCredential.md:
       title: HealthcareProfessionalDelegationCredential
       generation: markdown
+    credential-HealthcareProviderCredential.md:
+      title: HealthcareProviderCredential
+      generation: markdown
+    credential-ServiceProviderCredential.md:
+      title: ServiceProviderCredential
+      generation: markdown
+    credential-ServiceProviderDelegationCredential.md:
+      title: ServiceProviderDelegationCredential
+      generation: markdown
 
   history.md:
     title: History

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -129,6 +129,9 @@ pages:
     extension:
         - url: http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status
           valueCode: draft
+    credential-jsonld-context.md:
+      title: GIS JSON-LD Context
+      generation: markdown
     credential-X509Credential.md:
       title: X509Credential
       generation: markdown


### PR DESCRIPTION
Specifies three of the pilot credential types in the Credential Catalog, per nuts-foundation/lspxnuts-pilots#7. Aligned with the [AORTA-on-FHIR working version](https://aorta-on-fhir.public.vzvz.nl/aorta-on-fhir-specificaties/Working-version/verifiable-credentials).

## New credential pages (all `draft`)

| Credential | What it proves | Issuer | Sig alg |
|---|---|---|---|
| `ServiceProviderCredential` | Service provider is authorized within the agreement framework and competent to provide a service (system authorization, not delegation). | `did:web` system operator (`stelselhouder`) | ES256/ES512/PS256 |
| `HealthcareProviderCredential` | Identity of a healthcare provider by URA number. | `did:x509` UZI server cert (pastype `S`) | RS256 |
| `ServiceProviderDelegationCredential` | Healthcare provider delegates a scoped authorization to a service provider (delegation, not system authorization). | `did:web` healthcare provider | ES256/ES512/PS256 |

Each page covers: overview/profile (data model, proof type, signature algorithm, revocation, proof of possession), background, attribute table (with cardinality), entity-model diagram, JSON-LD context, VC 1.1 JWT example, validation rules, and use cases.

## Framework-generic, with AORTA specifics

`ServiceProviderCredential` and `ServiceProviderDelegationCredential` have an `afspraakstelsel`-neutral main spec. The framework-specific parts — issuer identity, the `.nl` did:web requirement, and the `services` / `authorizationRule` / `authorizedActions` value sets — live in an **Agreement framework specifics → AORTA** section. Other frameworks can be added as sibling subsections.

## GIS JSON-LD context extracted to one page

The context block is defined once on a dedicated **GIS JSON-LD Context** page; each credential page links to it instead of repeating the block. `issuedBy` was added (needed by `ServiceProviderDelegationCredential`).

## Editorial notes (`stu-note`) for open items

- The GIS context URL (`http://gis-nl.example/`) is a placeholder, still to be determined.
- The AORTA value sets for `authorizationRule` / `authorizedActions` are still to be determined (on both delegation credentials). The AORTA spec does not yet publish a concrete enumeration; the `gtk` rule and `tokenRequest`/`presentCredentials` actions are illustrative placeholders.


Assisted by AI